### PR TITLE
add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Binaries for programs and plugins
+bin
+build/
+testbin/*
+.gocache
+
+vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ build/
 testbin/*
 .gocache
 
+# Golang vendored dependencies
+vendor/
 
 # Test binary, build with `go test -c`
 *.test


### PR DESCRIPTION
i. add `vendor/` dir to gitignored files. I use `go mod vendor` to build and compile programs locally.
ii. add `.dockerignore` as best practice