### PR TITLE
ipam-node: Remove stale pool entries from the store

### DIFF
--- a/cmd/ipam-node/app/app.go
+++ b/cmd/ipam-node/app/app.go
@@ -243,7 +243,7 @@ func RunNodeDaemon(ctx context.Context, config *rest.Config, opts *options.Optio
 			}
 			return
 		}
-		c := cleaner.New(mgr.GetClient(), store, time.Minute, 3)
+		c := cleaner.New(mgr.GetClient(), store, poolManager, time.Minute, 3)
 		c.Start(innerCtx)
 		logger.Info("cleaner stopped")
 	}()

--- a/pkg/ipam-node/store/mocks/Session.go
+++ b/pkg/ipam-node/store/mocks/Session.go
@@ -308,6 +308,39 @@ func (_c *Session_ReleaseReservationByID_Call) RunAndReturn(run func(string, str
 	return _c
 }
 
+// RemovePool provides a mock function with given fields: pool
+func (_m *Session) RemovePool(pool string) {
+	_m.Called(pool)
+}
+
+// Session_RemovePool_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemovePool'
+type Session_RemovePool_Call struct {
+	*mock.Call
+}
+
+// RemovePool is a helper method to define mock.On call
+//   - pool string
+func (_e *Session_Expecter) RemovePool(pool interface{}) *Session_RemovePool_Call {
+	return &Session_RemovePool_Call{Call: _e.mock.On("RemovePool", pool)}
+}
+
+func (_c *Session_RemovePool_Call) Run(run func(pool string)) *Session_RemovePool_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Session_RemovePool_Call) Return() *Session_RemovePool_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *Session_RemovePool_Call) RunAndReturn(run func(string)) *Session_RemovePool_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Reserve provides a mock function with given fields: pool, id, ifName, meta, address
 func (_m *Session) Reserve(pool string, id string, ifName string, meta types.ReservationMetadata, address net.IP) error {
 	ret := _m.Called(pool, id, ifName, meta, address)

--- a/pkg/ipam-node/store/store.go
+++ b/pkg/ipam-node/store/store.go
@@ -60,6 +60,8 @@ type Session interface {
 	ListReservations(pool string) []types.Reservation
 	// ListPools return list with names of all known pools
 	ListPools() []string
+	// RemovePool removes information about the pool from the store
+	RemovePool(pool string)
 	// GetLastReservedIP returns last reserved IP for the pool or nil
 	GetLastReservedIP(pool string) net.IP
 	// SetLastReservedIP set last reserved IP fot the pool
@@ -254,6 +256,13 @@ func (s *session) ListPools() []string {
 		pools = append(pools, poolName)
 	}
 	return pools
+}
+
+// RemovePool is the Session interface implementation for session
+func (s *session) RemovePool(pool string) {
+	s.checkClosed()
+	delete(s.tmpData.Pools, pool)
+	s.isModified = true
 }
 
 // GetLastReservedIP is the Session interface implementation for session

--- a/pkg/ipam-node/store/store_test.go
+++ b/pkg/ipam-node/store/store_test.go
@@ -230,4 +230,12 @@ var _ = Describe("Store", func() {
 			s.Reserve(testPoolName, "other", testNetIfName,
 				types.ReservationMetadata{}, net.ParseIP(testIP))).To(MatchError(storePkg.ErrIPAlreadyReserved))
 	})
+	It("Remove pool data", func() {
+		s, err := store.Open(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		createTestReservation(s)
+		Expect(s.ListReservations(testPoolName)).NotTo(BeEmpty())
+		s.RemovePool(testPoolName)
+		Expect(s.ListReservations(testPoolName)).To(BeEmpty())
+	})
 })


### PR DESCRIPTION
remove the pool data from the store if the pool has no allocations and if information about the pool is unavailable in the Kubernetes API

closes #25