### PR TITLE
Use "preferred" podAntiAffinity instead of "required" for controller pod

### DIFF
--- a/deploy/nv-ipam.yaml
+++ b/deploy/nv-ipam.yaml
@@ -198,14 +198,16 @@ spec:
       serviceAccountName: nv-ipam-controller
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: name
-                    operator: In
-                    values:
-                      - nv-ipam-controller
-              topologyKey: "kubernetes.io/hostname"
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: name
+                      operator: In
+                      values:
+                        - nv-ipam-controller
+                topologyKey: "kubernetes.io/hostname"
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 1


### PR DESCRIPTION
This required to avoid problems with RollingUpdate on the single node cluster.

With the current affinity rule new pod instance will stuck in the pending state and this will block ipam-controller update.

network-operator already uses the right affinity rule, so the problem exist only in this repo.