### PR TITLE
Fix pod watch namespace for nv-ipam-node

### DIFF
--- a/cmd/ipam-node/app/app.go
+++ b/cmd/ipam-node/app/app.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/renameio/v2"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -39,6 +40,7 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -141,7 +143,11 @@ func RunNodeDaemon(ctx context.Context, config *rest.Config, opts *options.Optio
 		Scheme:                 scheme,
 		Metrics:                metricsserver.Options{BindAddress: opts.MetricsAddr},
 		HealthProbeBindAddress: opts.ProbeAddr,
-		Cache:                  cache.Options{DefaultNamespaces: map[string]cache.Config{opts.PoolsNamespace: {}}},
+		Cache: cache.Options{
+			DefaultNamespaces: map[string]cache.Config{opts.PoolsNamespace: {}},
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Pod{}: {Namespaces: map[string]cache.Config{cache.AllNamespaces: {}}}},
+		},
 	})
 	if err != nil {
 		logger.Error(err, "unable to initialize manager")

--- a/cmd/ipam-node/app/app.go
+++ b/cmd/ipam-node/app/app.go
@@ -154,6 +154,11 @@ func RunNodeDaemon(ctx context.Context, config *rest.Config, opts *options.Optio
 		return err
 	}
 
+	k8sClient, err := client.New(config, client.Options{Scheme: mgr.GetScheme(), Mapper: mgr.GetRESTMapper()})
+	if err != nil {
+		logger.Error(err, "unable to direct k8s client")
+	}
+
 	if err = (&ippoolctrl.IPPoolReconciler{
 		PoolManager: poolManager,
 		Client:      mgr.GetClient(),
@@ -258,7 +263,7 @@ func RunNodeDaemon(ctx context.Context, config *rest.Config, opts *options.Optio
 			}
 			return
 		}
-		c := cleaner.New(mgr.GetClient(), store, poolManager, time.Minute, 3)
+		c := cleaner.New(mgr.GetClient(), k8sClient, store, poolManager, time.Minute, 3)
 		c.Start(innerCtx)
 		logger.Info("cleaner stopped")
 	}()

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect

--- a/pkg/ipam-node/cleaner/cleaner_suite_test.go
+++ b/pkg/ipam-node/cleaner/cleaner_suite_test.go
@@ -24,15 +24,17 @@ import (
 
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
 var (
-	cfg       *rest.Config
-	k8sClient client.Client
-	testEnv   *envtest.Environment
-	cFunc     context.CancelFunc
-	ctx       context.Context
+	cfg        *rest.Config
+	k8sClient  client.Client
+	fakeClient client.Client
+	testEnv    *envtest.Environment
+	cFunc      context.CancelFunc
+	ctx        context.Context
 )
 
 func TestCleaner(t *testing.T) {
@@ -56,6 +58,9 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	fakeClient = fake.NewFakeClient()
+	Expect(fakeClient).NotTo(BeNil())
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/ipam-node/cleaner/cleaner_test.go
+++ b/pkg/ipam-node/cleaner/cleaner_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Cleaner", func() {
 			// this will create empty pool config
 			session.SetLastReservedIP(testPool3, net.ParseIP("192.168.33.100"))
 
-			cleaner := cleanerPkg.New(k8sClient, store, poolManager, time.Millisecond*100, 3)
+			cleaner := cleanerPkg.New(fakeClient, k8sClient, store, poolManager, time.Millisecond*100, 3)
 
 			pod1UID := createPod(testPodName1, testNamespace)
 			_ = createPod(testPodName2, testNamespace)


### PR DESCRIPTION
Before the fix,  nv-ipam-node was watching only for Pods in the namespace provided by `-- ippools-namespace` arg. This is incorrect and cause "stale IP cleaner" to work incorrectly.

Watch Pods in all namespaces instead.

\+ Add extra check to the cleaner to check Pod in the API (in addition to the cache)
before decide to cleanup the stale allocation.