### PR TITLE
Adjust CIDRPool to use int32 instead of uint fields

### DIFF
--- a/api/v1alpha1/cidrpool_type.go
+++ b/api/v1alpha1/cidrpool_type.go
@@ -38,10 +38,10 @@ type CIDRPoolSpec struct {
 	// and distributed between matching nodes
 	CIDR string `json:"cidr"`
 	// use IP with this index from the host prefix as a gateway, skip gateway configuration if the value not set
-	GatewayIndex *uint `json:"gatewayIndex,omitempty"`
+	GatewayIndex *int32 `json:"gatewayIndex,omitempty"`
 	// size of the network prefix for each host, the network defined in "cidr" field will be split to multiple networks
 	// with this size.
-	PerNodeNetworkPrefix uint `json:"perNodeNetworkPrefix"`
+	PerNodeNetworkPrefix int32 `json:"perNodeNetworkPrefix"`
 	// contains reserved IP addresses that should not be allocated by nv-ipam
 	Exclusions []ExcludeRange `json:"exclusions,omitempty"`
 	// static allocations for the pool

--- a/api/v1alpha1/cidrpool_validate.go
+++ b/api/v1alpha1/cidrpool_validate.go
@@ -51,9 +51,20 @@ func (r *CIDRPool) validateCIDR() field.ErrorList {
 		return field.ErrorList{field.Invalid(
 			field.NewPath("spec", "cidr"), r.Spec.CIDR, "single IP prefixes are not supported")}
 	}
+
+	if r.Spec.GatewayIndex != nil && *r.Spec.GatewayIndex < 0 {
+		return field.ErrorList{field.Invalid(
+			field.NewPath("spec", "gatewayIndex"), r.Spec.GatewayIndex, "must not be negative")}
+	}
+
+	if r.Spec.PerNodeNetworkPrefix < 0 {
+		return field.ErrorList{field.Invalid(
+			field.NewPath("spec", "perNodeNetworkPrefix"), r.Spec.PerNodeNetworkPrefix, "must not be negative")}
+	}
+
 	if r.Spec.PerNodeNetworkPrefix == 0 ||
-		r.Spec.PerNodeNetworkPrefix >= uint(bitsTotal) ||
-		r.Spec.PerNodeNetworkPrefix < uint(setBits) {
+		r.Spec.PerNodeNetworkPrefix >= int32(bitsTotal) ||
+		r.Spec.PerNodeNetworkPrefix < int32(setBits) {
 		return field.ErrorList{field.Invalid(
 			field.NewPath("spec", "perNodeNetworkPrefix"),
 			r.Spec.PerNodeNetworkPrefix, "must be less or equal than network prefix size in the \"cidr\" field")}

--- a/api/v1alpha1/helpers.go
+++ b/api/v1alpha1/helpers.go
@@ -27,7 +27,7 @@ import (
 // - subnet 192.168.0.0/24, index 10, gateway = 102.168.1.10
 // - subnet 192.168.1.2/31, index 0, gateway = 192.168.1.2 (point to point network can use network IP as a gateway)
 // - subnet 192.168.33.0/24, index 900, gateway = "" (invalid config, index too large)
-func GetGatewayForSubnet(subnet *net.IPNet, index uint) string {
+func GetGatewayForSubnet(subnet *net.IPNet, index int32) string {
 	setBits, bitsTotal := subnet.Mask.Size()
 	maxIndex := GetPossibleIPCount(subnet)
 

--- a/api/v1alpha1/helpers_test.go
+++ b/api/v1alpha1/helpers_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Helpers", func() {
 		func(subnet string, index int, gw string) {
 			_, network, err := net.ParseCIDR(subnet)
 			Expect(err).NotTo(HaveOccurred())
-			ret := v1alpha1.GetGatewayForSubnet(network, uint(index))
+			ret := v1alpha1.GetGatewayForSubnet(network, int32(index))
 			Expect(ret).To(Equal(gw))
 		},
 		Entry("ipv4 - start range", "192.168.1.0/24", 1, "192.168.1.1"),

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -116,7 +116,7 @@ func (in *CIDRPoolSpec) DeepCopyInto(out *CIDRPoolSpec) {
 	*out = *in
 	if in.GatewayIndex != nil {
 		in, out := &in.GatewayIndex, &out.GatewayIndex
-		*out = new(uint)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.Exclusions != nil {

--- a/cmd/ipam-controller/app/app_test.go
+++ b/cmd/ipam-controller/app/app_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	ipamv1alpha1 "github.com/Mellanox/nvidia-k8s-ipam/api/v1alpha1"
 	"github.com/Mellanox/nvidia-k8s-ipam/cmd/ipam-controller/app"
@@ -306,7 +307,6 @@ var _ = Describe("App", func() {
 
 	It("CIDRPool Basic tests", func(ctx SpecContext) {
 		By("Create valid pools")
-		pool1gatewayIndex := uint(1)
 		pool1 := &ipamv1alpha1.CIDRPool{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      pool1Name,
@@ -314,7 +314,7 @@ var _ = Describe("App", func() {
 			},
 			Spec: ipamv1alpha1.CIDRPoolSpec{
 				CIDR:                 "10.10.0.0/16",
-				GatewayIndex:         &pool1gatewayIndex,
+				GatewayIndex:         ptr.To[int32](1),
 				PerNodeNetworkPrefix: 24,
 				Exclusions: []ipamv1alpha1.ExcludeRange{
 					{StartIP: "10.10.1.22", EndIP: "10.10.1.30"},
@@ -329,7 +329,6 @@ var _ = Describe("App", func() {
 		}
 		Expect(k8sClient.Create(ctx, pool1)).NotTo(HaveOccurred())
 
-		pool2gatewayIndex := uint(1)
 		pool2 := &ipamv1alpha1.CIDRPool{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      pool2Name,
@@ -337,7 +336,7 @@ var _ = Describe("App", func() {
 			},
 			Spec: ipamv1alpha1.CIDRPoolSpec{
 				CIDR:                 "192.168.0.0/16",
-				GatewayIndex:         &pool2gatewayIndex,
+				GatewayIndex:         ptr.To[int32](1),
 				PerNodeNetworkPrefix: 31,
 			},
 		}
@@ -415,7 +414,6 @@ var _ = Describe("App", func() {
 
 		By("Create Pool3, with selector which ignores all nodes")
 		// ranges for two nodes only can be allocated
-		pool3gatewayIndex := uint(1)
 		pool3 := &ipamv1alpha1.CIDRPool{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      pool3Name,
@@ -423,7 +421,7 @@ var _ = Describe("App", func() {
 			},
 			Spec: ipamv1alpha1.CIDRPoolSpec{
 				CIDR:                 "10.10.0.0/24",
-				GatewayIndex:         &pool3gatewayIndex,
+				GatewayIndex:         ptr.To[int32](1),
 				PerNodeNetworkPrefix: 25,
 				NodeSelector: &corev1.NodeSelector{
 					NodeSelectorTerms: []corev1.NodeSelectorTerm{

--- a/cmd/ipam-node/app/app_test.go
+++ b/cmd/ipam-node/app/app_test.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	nodev1 "github.com/Mellanox/nvidia-k8s-ipam/api/grpc/nvidia/ipam/node/v1"
 	ipamv1alpha1 "github.com/Mellanox/nvidia-k8s-ipam/api/v1alpha1"
@@ -84,12 +85,11 @@ func createTestIPPools() {
 }
 
 func createTestCIDRPools() {
-	pool1GatewayIndex := uint(1)
 	pool1 := &ipamv1alpha1.CIDRPool{
 		ObjectMeta: metav1.ObjectMeta{Name: testPoolName1, Namespace: testNamespace},
 		Spec: ipamv1alpha1.CIDRPoolSpec{
 			CIDR:                 "192.100.0.0/16",
-			GatewayIndex:         &pool1GatewayIndex,
+			GatewayIndex:         ptr.To[int32](1),
 			PerNodeNetworkPrefix: 24,
 			Exclusions: []ipamv1alpha1.ExcludeRange{
 				{StartIP: "192.100.0.1", EndIP: "192.100.0.10"},

--- a/deploy/crds/nv-ipam.nvidia.com_cidrpools.yaml
+++ b/deploy/crds/nv-ipam.nvidia.com_cidrpools.yaml
@@ -68,6 +68,7 @@ spec:
               gatewayIndex:
                 description: use IP with this index from the host prefix as a gateway,
                   skip gateway configuration if the value not set
+                format: int32
                 type: integer
               nodeSelector:
                 description: selector for nodes, if empty match all nodes
@@ -157,6 +158,7 @@ spec:
                 description: size of the network prefix for each host, the network
                   defined in "cidr" field will be split to multiple networks with
                   this size.
+                format: int32
                 type: integer
               staticAllocations:
                 description: static allocations for the pool

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	k8s.io/component-base v0.29.3
 	k8s.io/component-helpers v0.29.3
 	k8s.io/klog/v2 v2.120.1
+	k8s.io/utils v0.0.0-20240310230437-4693a0247e57
 	sigs.k8s.io/controller-runtime v0.17.2
 )
 
@@ -82,7 +83,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.29.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
-	k8s.io/utils v0.0.0-20240310230437-4693a0247e57 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -178,9 +178,9 @@ func LastIP(network *net.IPNet) net.IP {
 // println(gen().String()) // 192.168.1.0/25
 // println(gen().String()) // 192.168.1.128/25
 // println(gen().String()) // <nil> - no more ranges available
-func GetSubnetGen(network *net.IPNet, prefixSize uint) func() *net.IPNet {
+func GetSubnetGen(network *net.IPNet, prefixSize int32) func() *net.IPNet {
 	networkOnes, netBitsTotal := network.Mask.Size()
-	if prefixSize < uint(networkOnes) || prefixSize > uint(netBitsTotal) {
+	if prefixSize < int32(networkOnes) || prefixSize > int32(netBitsTotal) {
 		return func() *net.IPNet { return nil }
 	}
 	isIPv6 := false


### PR DESCRIPTION
According to the [API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#primitive-types), we should not use `uint` type for fields. 
> * All public integer fields MUST use the Go int32 or Go int64 types, not int (which is ambiguously sized, depending on target platform). Internal types may use int.
> * Do not use unsigned integers, due to inconsistent support across languages and libraries. Just validate that the integer is non-negative if that's the case. 

In fact, issues using `uint` can also be observed when trying to `DeepCopyJSON` the object that panics with error `panic: cannot deep copy uint64`. (e.g. convert the object to `unstructured.Unstructured` and then call `unstructuredObj.DeepCopy()`)

Upstream issue: https://github.com/kubernetes/kubernetes/issues/62769

---

This PR adjusts the `uint` fields to `int32`. This means that we can fully cover the IPv4 address family, but we impose limitations for the IPv6 address family since the `gatewayIndex` and `PerNodeNetworkPrefix` can go up to 2^32.