### PR TITLE
fix: CNI arg name in the example in extra-cni-args.md

### DIFF
--- a/docs/extra-cni-args.md
+++ b/docs/extra-cni-args.md
@@ -24,7 +24,7 @@ metadata:
     k8s.v1.cni.cncf.io/networks: '
       [{"name": "mynet",
         "cni-args":
-            {"poolName": ["pool1"],
+            {"poolNames": ["pool1"],
              "poolType": "cidrpool",
              "allocateDefaultGateway": true}}]'
 spec:


### PR DESCRIPTION
The correct name is "poolNames"