### PR TITLE
Add option to force specifying pool name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the image
-FROM golang:1.21 as builder
+FROM golang:1.21 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/README.md
+++ b/README.md
@@ -559,6 +559,8 @@ Shim CNI Configuration flags:
                 shim CNI config: timeout for IPAM daemon calls (default 5)
       --cni-daemon-socket string                                                                                                                                                                     
                 shim CNI config: IPAM daemon socket path (default "unix:///var/lib/cni/nv-ipam/daemon.sock")
+      --cni-force-pool-name string
+                shim CNI config: force specifying pool name in CNI configuration
       --cni-log-file string                                                                                                                                                                          
                 shim CNI config: path to log file for shim CNI (default "/var/log/nv-ipam-cni.log")
       --cni-log-level string                                                                                                                                                                         
@@ -579,6 +581,7 @@ nv-ipam accepts the following CNI configuration:
 ```json
 {
     "type": "nv-ipam",
+    "forcePoolName" : false,
     "poolName": "pool1,pool2",
     "poolType": "ippool",
     "daemonSocket": "unix:///var/lib/cni/nv-ipam/daemon.sock",
@@ -590,6 +593,7 @@ nv-ipam accepts the following CNI configuration:
 ```
 
 * `type` (string, required): CNI plugin name, MUST be `"nv-ipam"`
+* `forcePoolName` (bool, optional): force specifying pool name in CNI configuration.
 * `poolName` (string, optional): name of the Pool to be used for IP allocation.
 It is possible to allocate two IPs for the interface from different pools by specifying pool names separated by coma,
 e.g. `"my-ipv4-pool,my-ipv6-pool"`. The primary intent to support multiple pools is a dual-stack use-case when an 

--- a/cmd/ipam-node/app/app.go
+++ b/cmd/ipam-node/app/app.go
@@ -359,9 +359,9 @@ func createNVIPAMConfig(log logr.Logger, opts *options.Options) error {
   "daemonSocket":    "%s",
   "daemonCallTimeoutSeconds":    %d,
   "logFile":   "%s",
-  "logLevel": "%s"
-}
-`, opts.CNIDaemonSocket, opts.CNIDaemonCallTimeoutSeconds, opts.CNILogFile, opts.CNILogLevel)
+  "logLevel": "%s",
+  "forcePoolName": %v
+}`, opts.CNIDaemonSocket, opts.CNIDaemonCallTimeoutSeconds, opts.CNILogFile, opts.CNILogLevel, opts.CNIForcePoolName)
 
 	err := renameio.WriteFile(filepath.Join(opts.CNIConfDir, cniTypes.ConfFileName), []byte(cfg), 0664)
 	if err != nil {

--- a/cmd/ipam-node/app/options/options.go
+++ b/cmd/ipam-node/app/options/options.go
@@ -53,6 +53,7 @@ func New() *Options {
 		CNIConfDir:                  cniTypes.DefaultConfDir,
 		CNILogLevel:                 cniTypes.DefaultLogLevel,
 		CNILogFile:                  cniTypes.DefaultLogFile,
+		CNIForcePoolName:            false,
 	}
 }
 
@@ -75,6 +76,7 @@ type Options struct {
 	CNIDaemonCallTimeoutSeconds int
 	CNILogFile                  string
 	CNILogLevel                 string
+	CNIForcePoolName            bool
 }
 
 // AddNamedFlagSets register flags for common options in NamedFlagSets
@@ -119,6 +121,8 @@ func (o *Options) AddNamedFlagSets(sharedFS *cliflag.NamedFlagSets) {
 		"shim CNI config: path to log file for shim CNI")
 	cniFS.StringVar(&o.CNILogLevel, "cni-log-level", o.CNILogLevel,
 		"shim CNI config: log level for shim CNI")
+	cniFS.BoolVar(&o.CNIForcePoolName, "cni-force-pool-name", o.CNIForcePoolName,
+		"shim CNI config: force specifying pool name in CNI configuration")
 }
 
 // Validate registered options

--- a/pkg/cni/types/types_test.go
+++ b/pkg/cni/types/types_test.go
@@ -109,6 +109,31 @@ var _ = Describe("Types Tests", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
+		It("Fails if CNI stdin data does not contain pool name and forcePoolName is set in config file", func() {
+			// write config file
+			confData := `{"forcePoolName": true}`
+			err := os.WriteFile(path.Join(testConfDir, cniTypes.ConfFileName), []byte(confData), 0o644)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Load CNI config
+			testConf := fmt.Sprintf(`{"name": "my-net", "ipam": {"confDir": %q}}`, testConfDir)
+			_, err = cniTypes.NewConfLoader().LoadConf(&skel.CmdArgs{
+				StdinData: []byte(testConf), Args: testArgs})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Fails if CNI stdin data does not contain pool name and forcePoolName is set", func() {
+			// write empty config file
+			err := os.WriteFile(path.Join(testConfDir, cniTypes.ConfFileName), []byte("{}"), 0o644)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Load CNI config
+			testConf := fmt.Sprintf(`{"name": "my-net", "ipam": {"confDir": %q, "forcePoolName": true}}`, testConfDir)
+			_, err = cniTypes.NewConfLoader().LoadConf(&skel.CmdArgs{
+				StdinData: []byte(testConf), Args: testArgs})
+			Expect(err).To(HaveOccurred())
+		})
+
 		It("Missing metadata arguments", func() {
 			// write config file
 			confData := `{"logLevel": "debug", "logFile": "some/path.log"}`


### PR DESCRIPTION
in some cases it is desired to make specifying at least one pool in poolName or pools mandatory. To achieve this we add a new IPAM CNI parameter which can be defined in nv-ipam config file. this will prevent CNI from using network name as pool name in case poolName was not specified.