### PR TITLE
Add support for /32 (/128) networks and perNodeBlockSize 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ spec:
 > __Notes:__
 >
 > * pool name is composed of alphanumeric letters separated by dots(`.`) underscores(`_`) or hyphens(`-`).
-> * `perNodeBlockSize` minimum size is 2.
+> * `perNodeBlockSize` minimum size is 1.
 > * `subnet` must be large enough to accommodate at least one `perNodeBlockSize` block of IPs.
 
 

--- a/api/v1alpha1/cidrpool_test.go
+++ b/api/v1alpha1/cidrpool_test.go
@@ -185,8 +185,8 @@ var _ = Describe("CIDRPool", func() {
 		},
 		Entry("empty", "", int32(30), false),
 		Entry("invalid value", "aaaa", int32(30), false),
-		Entry("/32", "192.168.1.1/32", int32(32), false),
-		Entry("/128", "2001:db8:3333:4444::0/128", int32(128), false),
+		Entry("/32", "192.168.1.1/32", int32(32), true),
+		Entry("/128", "2001:db8:3333:4444::0/128", int32(128), true),
 		Entry("valid ipv4", "192.168.1.0/24", int32(30), true),
 		Entry("valid ipv6", "2001:db8:3333:4444::0/64", int32(120), true),
 	)
@@ -203,8 +203,8 @@ var _ = Describe("CIDRPool", func() {
 		Entry("not set", "192.168.0.0/16", int32(0), false),
 		Entry("negative", "192.168.0.0/16", int32(-10), false),
 		Entry("larger than CIDR", "192.168.0.0/16", int32(8), false),
-		Entry("smaller than 31 for IPv4 pool", "192.168.0.0/16", int32(32), false),
-		Entry("smaller than 127 for IPv6 pool", "2001:db8:3333:4444::0/64", int32(128), false),
+		Entry("32 for IPv4 pool", "192.168.0.0/16", int32(32), true),
+		Entry("128 for IPv6 pool", "2001:db8:3333:4444::0/64", int32(128), true),
 		Entry("match CIDR prefix size - ipv4", "192.168.0.0/16", int32(16), true),
 		Entry("match CIDR prefix size - ipv6", "2001:db8:3333:4444::0/64", int32(64), true),
 	)

--- a/api/v1alpha1/cidrpool_validate.go
+++ b/api/v1alpha1/cidrpool_validate.go
@@ -60,12 +60,6 @@ func (r *CIDRPool) validateCIDR() field.ErrorList {
 		return field.ErrorList{field.Invalid(field.NewPath("spec", "cidr"), r.Spec.CIDR, "network prefix has host bits set")}
 	}
 
-	setBits, bitsTotal := network.Mask.Size()
-	if setBits == bitsTotal {
-		return field.ErrorList{field.Invalid(
-			field.NewPath("spec", "cidr"), r.Spec.CIDR, "single IP prefixes are not supported")}
-	}
-
 	if r.Spec.GatewayIndex != nil && *r.Spec.GatewayIndex < 0 {
 		return field.ErrorList{field.Invalid(
 			field.NewPath("spec", "gatewayIndex"), r.Spec.GatewayIndex, "must not be negative")}
@@ -75,9 +69,9 @@ func (r *CIDRPool) validateCIDR() field.ErrorList {
 		return field.ErrorList{field.Invalid(
 			field.NewPath("spec", "perNodeNetworkPrefix"), r.Spec.PerNodeNetworkPrefix, "must not be negative")}
 	}
-
+	setBits, bitsTotal := network.Mask.Size()
 	if r.Spec.PerNodeNetworkPrefix == 0 ||
-		r.Spec.PerNodeNetworkPrefix >= int32(bitsTotal) ||
+		r.Spec.PerNodeNetworkPrefix > int32(bitsTotal) ||
 		r.Spec.PerNodeNetworkPrefix < int32(setBits) {
 		return field.ErrorList{field.Invalid(
 			field.NewPath("spec", "perNodeNetworkPrefix"),

--- a/api/v1alpha1/ippool_validate.go
+++ b/api/v1alpha1/ippool_validate.go
@@ -35,13 +35,13 @@ func (r *IPPool) Validate() field.ErrorList {
 			field.NewPath("spec", "subnet"), r.Spec.Subnet, "is invalid subnet"))
 	}
 
-	if r.Spec.PerNodeBlockSize < 2 {
+	if r.Spec.PerNodeBlockSize < 1 {
 		errList = append(errList, field.Invalid(
 			field.NewPath("spec", "perNodeBlockSize"),
-			r.Spec.PerNodeBlockSize, "must be at least 2"))
+			r.Spec.PerNodeBlockSize, "must be at least 1"))
 	}
 
-	if network != nil && r.Spec.PerNodeBlockSize >= 2 {
+	if network != nil && r.Spec.PerNodeBlockSize >= 1 {
 		if GetPossibleIPCount(network).Cmp(big.NewInt(int64(r.Spec.PerNodeBlockSize))) < 0 {
 			// config is not valid even if only one node exist in the cluster
 			errList = append(errList, field.Invalid(

--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -138,6 +138,9 @@ func IsBroadcast(ip net.IP, network *net.IPNet) bool {
 	if network.IP.To4() == nil {
 		return false
 	}
+	if IsPointToPointSubnet(network) || IsSingleIPSubnet(network) {
+		return false
+	}
 	if !network.Contains(ip) {
 		return false
 	}
@@ -153,8 +156,17 @@ func IsPointToPointSubnet(network *net.IPNet) bool {
 	return ones == maskLen-1
 }
 
+// IsSingleIPSubnet returns true if the network is a single IP subnet (/32 or /128)
+func IsSingleIPSubnet(network *net.IPNet) bool {
+	ones, maskLen := network.Mask.Size()
+	return ones == maskLen
+}
+
 // LastIP returns the last IP of a subnet, excluding the broadcast if IPv4 (if not /31 net)
 func LastIP(network *net.IPNet) net.IP {
+	if IsSingleIPSubnet(network) {
+		return network.IP
+	}
 	var end net.IP
 	for i := 0; i < len(network.IP); i++ {
 		end = append(end, network.IP[i]|^network.Mask[i])

--- a/pkg/ipam-controller/allocator/allocator_test.go
+++ b/pkg/ipam-controller/allocator/allocator_test.go
@@ -35,7 +35,7 @@ const (
 	testPoolName1          = "pool1"
 	testPoolName2          = "pool2"
 	testPerNodeBlockCount1 = 15
-	testPerNodeBlockCount2 = 10
+	testPerNodeBlockCount2 = 1
 )
 
 func getPool1() *ipamv1alpha1.IPPool {
@@ -54,7 +54,7 @@ func getPool2() *ipamv1alpha1.IPPool {
 		Spec: ipamv1alpha1.IPPoolSpec{
 			Subnet:           "172.16.0.0/16",
 			PerNodeBlockSize: testPerNodeBlockCount2,
-			Gateway:          "172.16.0.1"},
+			Gateway:          "172.16.0.3"},
 	}
 }
 
@@ -79,7 +79,7 @@ var _ = Describe("Allocator", func() {
 		Expect(node1AllocPool1.StartIP.String()).To(BeEquivalentTo("192.168.0.1"))
 		Expect(node1AllocPool1.EndIP.String()).To(BeEquivalentTo("192.168.0.15"))
 		Expect(node1AllocPool2.StartIP.String()).To(BeEquivalentTo("172.16.0.1"))
-		Expect(node1AllocPool2.EndIP.String()).To(BeEquivalentTo("172.16.0.10"))
+		Expect(node1AllocPool2.EndIP.String()).To(BeEquivalentTo("172.16.0.1"))
 
 		node1AllocSecondCall, err := pa1.AllocateFromPool(ctx, testNodeName1)
 		Expect(err).NotTo(HaveOccurred())
@@ -95,8 +95,8 @@ var _ = Describe("Allocator", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(node2AllocPool1.StartIP.String()).To(BeEquivalentTo("192.168.0.16"))
 		Expect(node2AllocPool1.EndIP.String()).To(BeEquivalentTo("192.168.0.30"))
-		Expect(node2AllocPool2.StartIP.String()).To(BeEquivalentTo("172.16.0.11"))
-		Expect(node2AllocPool2.EndIP.String()).To(BeEquivalentTo("172.16.0.20"))
+		Expect(node2AllocPool2.StartIP.String()).To(BeEquivalentTo("172.16.0.2"))
+		Expect(node2AllocPool2.EndIP.String()).To(BeEquivalentTo("172.16.0.2"))
 
 		node3AllocPool1, err := pa1.AllocateFromPool(ctx, testNodeName3)
 		Expect(err).NotTo(HaveOccurred())
@@ -104,8 +104,8 @@ var _ = Describe("Allocator", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(node3AllocPool1.StartIP.String()).To(BeEquivalentTo("192.168.0.31"))
 		Expect(node3AllocPool1.EndIP.String()).To(BeEquivalentTo("192.168.0.45"))
-		Expect(node3AllocPool2.StartIP.String()).To(BeEquivalentTo("172.16.0.21"))
-		Expect(node3AllocPool2.EndIP.String()).To(BeEquivalentTo("172.16.0.30"))
+		Expect(node3AllocPool2.StartIP.String()).To(BeEquivalentTo("172.16.0.4"))
+		Expect(node3AllocPool2.EndIP.String()).To(BeEquivalentTo("172.16.0.4"))
 
 		node4AllocPool1, err := pa1.AllocateFromPool(ctx, testNodeName4)
 		Expect(err).NotTo(HaveOccurred())
@@ -113,8 +113,8 @@ var _ = Describe("Allocator", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(node4AllocPool1.StartIP.String()).To(BeEquivalentTo("192.168.0.46"))
 		Expect(node4AllocPool1.EndIP.String()).To(BeEquivalentTo("192.168.0.60"))
-		Expect(node4AllocPool2.StartIP.String()).To(BeEquivalentTo("172.16.0.31"))
-		Expect(node4AllocPool2.EndIP.String()).To(BeEquivalentTo("172.16.0.40"))
+		Expect(node4AllocPool2.StartIP.String()).To(BeEquivalentTo("172.16.0.5"))
+		Expect(node4AllocPool2.EndIP.String()).To(BeEquivalentTo("172.16.0.5"))
 
 		// deallocate for node3 and node1
 		pa1.Deallocate(ctx, testNodeName1)
@@ -130,7 +130,7 @@ var _ = Describe("Allocator", func() {
 		Expect(node3AllocPool1.StartIP.String()).To(BeEquivalentTo("192.168.0.1"))
 		Expect(node3AllocPool1.EndIP.String()).To(BeEquivalentTo("192.168.0.15"))
 		Expect(node3AllocPool2.StartIP.String()).To(BeEquivalentTo("172.16.0.1"))
-		Expect(node3AllocPool2.EndIP.String()).To(BeEquivalentTo("172.16.0.10"))
+		Expect(node3AllocPool2.EndIP.String()).To(BeEquivalentTo("172.16.0.1"))
 
 		node1AllocPool1, err = pa1.AllocateFromPool(ctx, testNodeName1)
 		Expect(err).ToNot(HaveOccurred())
@@ -138,8 +138,8 @@ var _ = Describe("Allocator", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(node1AllocPool1.StartIP.String()).To(BeEquivalentTo("192.168.0.31"))
 		Expect(node1AllocPool1.EndIP.String()).To(BeEquivalentTo("192.168.0.45"))
-		Expect(node1AllocPool2.StartIP.String()).To(BeEquivalentTo("172.16.0.21"))
-		Expect(node1AllocPool2.EndIP.String()).To(BeEquivalentTo("172.16.0.30"))
+		Expect(node1AllocPool2.StartIP.String()).To(BeEquivalentTo("172.16.0.4"))
+		Expect(node1AllocPool2.EndIP.String()).To(BeEquivalentTo("172.16.0.4"))
 	})
 
 	It("Deallocate from pool", func() {
@@ -234,6 +234,144 @@ var _ = Describe("Allocator", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(node2AllocPool1.StartIP.String()).To(BeEquivalentTo("192.168.0.16"))
 		Expect(node2AllocPool1.EndIP.String()).To(BeEquivalentTo("192.168.0.30"))
+	})
+
+	It("Load single IP range", func() {
+		pool2 := getPool2()
+		pool2.Status = ipamv1alpha1.IPPoolStatus{
+			Allocations: []ipamv1alpha1.Allocation{
+				{
+					NodeName: testNodeName1,
+					StartIP:  "172.16.0.1",
+					EndIP:    "172.16.0.1",
+				},
+				{
+					// should discard, overlaps with GW
+					NodeName: testNodeName2,
+					StartIP:  "172.16.0.3",
+					EndIP:    "172.16.0.3",
+				},
+				{
+					NodeName: testNodeName3,
+					StartIP:  "172.16.0.4",
+					EndIP:    "172.16.0.4",
+				},
+			},
+		}
+		selectedNodes := sets.New(testNodeName1, testNodeName2)
+		a := allocator.CreatePoolAllocatorFromIPPool(ctx, pool2, selectedNodes)
+		node1AllocPool, err := a.AllocateFromPool(ctx, testNodeName1)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(node1AllocPool.StartIP.String()).To(BeEquivalentTo("172.16.0.1"))
+		Expect(node1AllocPool.EndIP.String()).To(BeEquivalentTo("172.16.0.1"))
+		node2AllocPool, err := a.AllocateFromPool(ctx, testNodeName2)
+		Expect(err).ToNot(HaveOccurred())
+		// should get the new IP
+		Expect(node2AllocPool.StartIP.String()).To(BeEquivalentTo("172.16.0.2"))
+		Expect(node2AllocPool.EndIP.String()).To(BeEquivalentTo("172.16.0.2"))
+		// should get IP from the status
+		node3AllocPool, err := a.AllocateFromPool(ctx, testNodeName3)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(node3AllocPool.StartIP.String()).To(BeEquivalentTo("172.16.0.4"))
+		Expect(node3AllocPool.EndIP.String()).To(BeEquivalentTo("172.16.0.4"))
+	})
+
+	Context("small pools", func() {
+		It("/32 pool - can allocate if no gw", func() {
+			pool := &ipamv1alpha1.IPPool{
+				ObjectMeta: v1.ObjectMeta{Name: "small-pool"},
+				Spec: ipamv1alpha1.IPPoolSpec{
+					Subnet:           "10.10.10.10/32",
+					PerNodeBlockSize: 1,
+				},
+			}
+			a := allocator.CreatePoolAllocatorFromIPPool(ctx, pool, sets.New(testNodeName1, testNodeName2))
+			node1Alloc, err := a.AllocateFromPool(ctx, testNodeName1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node1Alloc.StartIP.String()).To(BeEquivalentTo("10.10.10.10"))
+			Expect(node1Alloc.EndIP.String()).To(BeEquivalentTo("10.10.10.10"))
+			_, err = a.AllocateFromPool(ctx, testNodeName2)
+			Expect(errors.Is(err, allocator.ErrNoFreeRanges)).To(BeTrue())
+		})
+		It("/32 pool - can't allocate if gw set", func() {
+			pool := &ipamv1alpha1.IPPool{
+				ObjectMeta: v1.ObjectMeta{Name: "small-pool"},
+				Spec: ipamv1alpha1.IPPoolSpec{
+					Subnet:           "10.10.10.10/32",
+					PerNodeBlockSize: 1,
+					Gateway:          "10.10.10.10",
+				},
+			}
+			a := allocator.CreatePoolAllocatorFromIPPool(ctx, pool, sets.New(testNodeName1, testNodeName2))
+			_, err := a.AllocateFromPool(ctx, testNodeName1)
+			Expect(errors.Is(err, allocator.ErrNoFreeRanges)).To(BeTrue())
+		})
+		It("/31 pool - can allocate 2 ips", func() {
+			pool := &ipamv1alpha1.IPPool{
+				ObjectMeta: v1.ObjectMeta{Name: "small-pool"},
+				Spec: ipamv1alpha1.IPPoolSpec{
+					Subnet:           "10.10.10.10/31",
+					PerNodeBlockSize: 2,
+				},
+			}
+			a := allocator.CreatePoolAllocatorFromIPPool(ctx, pool, sets.New(testNodeName1, testNodeName2))
+			node1Alloc, err := a.AllocateFromPool(ctx, testNodeName1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node1Alloc.StartIP.String()).To(BeEquivalentTo("10.10.10.10"))
+			Expect(node1Alloc.EndIP.String()).To(BeEquivalentTo("10.10.10.11"))
+			_, err = a.AllocateFromPool(ctx, testNodeName2)
+			Expect(errors.Is(err, allocator.ErrNoFreeRanges)).To(BeTrue())
+		})
+		It("/31 pool - can allocate 1 ip for 2 nodes", func() {
+			pool := &ipamv1alpha1.IPPool{
+				ObjectMeta: v1.ObjectMeta{Name: "small-pool"},
+				Spec: ipamv1alpha1.IPPoolSpec{
+					Subnet:           "10.10.10.10/31",
+					PerNodeBlockSize: 1,
+				},
+			}
+			a := allocator.CreatePoolAllocatorFromIPPool(ctx, pool, sets.New(testNodeName1, testNodeName2))
+			node1Alloc, err := a.AllocateFromPool(ctx, testNodeName1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node1Alloc.StartIP.String()).To(BeEquivalentTo("10.10.10.10"))
+			Expect(node1Alloc.EndIP.String()).To(BeEquivalentTo("10.10.10.10"))
+			node2Alloc, err := a.AllocateFromPool(ctx, testNodeName2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node2Alloc.StartIP.String()).To(BeEquivalentTo("10.10.10.11"))
+			Expect(node2Alloc.EndIP.String()).To(BeEquivalentTo("10.10.10.11"))
+		})
+		It("/31 pool - load allocations", func ()  {
+			pool := &ipamv1alpha1.IPPool{
+				ObjectMeta: v1.ObjectMeta{Name: "small-pool"},
+				Spec: ipamv1alpha1.IPPoolSpec{
+					Subnet:           "10.10.10.10/31",
+					PerNodeBlockSize: 1,
+				},
+			}
+			pool.Status = ipamv1alpha1.IPPoolStatus{
+				Allocations: []ipamv1alpha1.Allocation{
+					{
+						NodeName: testNodeName1,
+						StartIP:  "10.10.10.10",
+						EndIP:    "10.10.10.10",
+					},
+					{
+						NodeName: testNodeName2,
+						StartIP:  "10.10.10.11",
+						EndIP:    "10.10.10.11",
+					},
+				},
+			}
+			a := allocator.CreatePoolAllocatorFromIPPool(ctx, pool, sets.New(testNodeName1, testNodeName2))
+			node2Alloc, err := a.AllocateFromPool(ctx, testNodeName2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node2Alloc.StartIP.String()).To(BeEquivalentTo("10.10.10.11"))
+			Expect(node2Alloc.EndIP.String()).To(BeEquivalentTo("10.10.10.11"))
+			node1Alloc, err := a.AllocateFromPool(ctx, testNodeName1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node1Alloc.StartIP.String()).To(BeEquivalentTo("10.10.10.10"))
+			Expect(node1Alloc.EndIP.String()).To(BeEquivalentTo("10.10.10.10"))
+		})
 	})
 
 	It("ConfigureAndLoadAllocations - Data load test", func() {

--- a/pkg/ipam-controller/config/config_test.go
+++ b/pkg/ipam-controller/config/config_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Config", func() {
 	})
 	It("Invalid pool: perNodeBlockSize too small", func() {
 		poolConfig := getValidPool()
-		poolConfig.PerNodeBlockSize = 1
+		poolConfig.PerNodeBlockSize = 0
 		cfg := &config.Config{Pools: map[string]config.PoolConfig{"pool1": poolConfig}}
 		Expect(cfg.Validate()).To(HaveOccurred())
 	})

--- a/pkg/ipam-node/controllers/cidrpool/cidrpool_test.go
+++ b/pkg/ipam-node/controllers/cidrpool/cidrpool_test.go
@@ -14,13 +14,33 @@
 package controllers
 
 import (
+	"context"
 	"net"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
 	ipamv1alpha1 "github.com/Mellanox/nvidia-k8s-ipam/api/v1alpha1"
+	"github.com/Mellanox/nvidia-k8s-ipam/pkg/common"
 	"github.com/Mellanox/nvidia-k8s-ipam/pkg/pool"
+	poolPkg "github.com/Mellanox/nvidia-k8s-ipam/pkg/pool"
+)
+
+const (
+	testNamespace = "test-ns"
+	testNodeName  = "test-node"
 )
 
 var _ = Describe("CIDRPool", func() {
@@ -67,4 +87,180 @@ var _ = Describe("CIDRPool", func() {
 			},
 		),
 	)
+	Context("Controller tests", Ordered, func() {
+		var (
+			err         error
+			cfg         *rest.Config
+			k8sClient   client.Client
+			testEnv     *envtest.Environment
+			cancelFunc  context.CancelFunc
+			ctx         context.Context
+			poolManager poolPkg.Manager
+		)
+
+		BeforeAll(func() {
+			poolManager = poolPkg.NewManager()
+			By("bootstrapping test environment")
+			testEnv = &envtest.Environment{
+				CRDDirectoryPaths: []string{"../../../../deploy/crds"},
+				CRDInstallOptions: envtest.CRDInstallOptions{
+					ErrorIfPathMissing: true,
+				},
+			}
+			ctx, cancelFunc = context.WithCancel(context.Background())
+			Expect(ipamv1alpha1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+
+			cfg, err = testEnv.Start()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg).NotTo(BeNil())
+
+			k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient).NotTo(BeNil())
+
+			Expect(k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}})).To(BeNil())
+
+			mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+				Scheme:  scheme.Scheme,
+				Metrics: metricsserver.Options{BindAddress: "0"},
+				Cache: cache.Options{
+					DefaultNamespaces: map[string]cache.Config{testNamespace: {}},
+					ByObject: map[client.Object]cache.ByObject{
+						&corev1.Pod{}: {Namespaces: map[string]cache.Config{cache.AllNamespaces: {}}}},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect((&CIDRPoolReconciler{
+				PoolManager: poolManager,
+				Client:      mgr.GetClient(),
+				Scheme:      mgr.GetScheme(),
+				NodeName:    testNodeName,
+			}).SetupWithManager(mgr)).NotTo(HaveOccurred())
+
+			go func() {
+				defer GinkgoRecover()
+				Expect(mgr.Start(ctx)).NotTo(HaveOccurred())
+			}()
+		})
+		AfterAll(func() {
+			cancelFunc()
+			By("tearing down the test environment")
+			err := testEnv.Stop()
+			Expect(err).NotTo(HaveOccurred())
+		})
+		AfterEach(func() {
+			cidrPoolList := &ipamv1alpha1.CIDRPoolList{}
+			Expect(k8sClient.List(ctx, cidrPoolList)).NotTo(HaveOccurred())
+			for _, p := range cidrPoolList.Items {
+				Expect(k8sClient.Delete(ctx, &p)).NotTo(HaveOccurred())
+			}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.List(ctx, cidrPoolList)).NotTo(HaveOccurred())
+				g.Expect(cidrPoolList.Items).To(BeEmpty())
+				g.Expect(poolManager.GetPools()).To(BeEmpty())
+			}).WithTimeout(time.Minute).WithPolling(time.Second).Should(Succeed())
+		})
+		It("Valid pool config", func() {
+			p := &ipamv1alpha1.CIDRPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: testNamespace},
+				Spec: ipamv1alpha1.CIDRPoolSpec{
+					CIDR:                 "10.10.0.0/16",
+					GatewayIndex:         ptr.To[int32](1),
+					PerNodeNetworkPrefix: 24,
+					Exclusions: []ipamv1alpha1.ExcludeRange{
+						{StartIP: "10.10.33.10", EndIP: "10.10.33.20"},
+						{StartIP: "10.10.10.10", EndIP: "10.10.10.20"},
+					},
+					DefaultGateway: true,
+					Routes:         []ipamv1alpha1.Route{{Dst: "5.5.5.5/32"}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, p)).NotTo(HaveOccurred())
+			p.Status.Allocations = []ipamv1alpha1.CIDRPoolAllocation{{
+				NodeName: testNodeName,
+				Gateway:  "10.10.10.1",
+				Prefix:   "10.10.10.0/24",
+			}}
+			Expect(k8sClient.Status().Update(ctx, p)).NotTo(HaveOccurred())
+			Eventually(func(g Gomega) {
+				g.Expect(poolManager.GetPoolByKey(
+					common.GetPoolKey("test-pool", common.PoolTypeCIDRPool))).To(
+					Equal(&pool.Pool{
+						Name:    "test-pool",
+						Subnet:  "10.10.10.0/24",
+						StartIP: "10.10.10.1",
+						EndIP:   "10.10.10.254",
+						Gateway: "10.10.10.1",
+						Exclusions: []pool.ExclusionRange{{
+							StartIP: "10.10.10.10",
+							EndIP:   "10.10.10.20",
+						}},
+						Routes:         []pool.Route{{Dst: "5.5.5.5/32"}},
+						DefaultGateway: true,
+					}))
+			}).WithTimeout(time.Second * 15).WithPolling(time.Second).Should(Succeed())
+		})
+		It("Valid pool config /32 cidr", func() {
+			p := &ipamv1alpha1.CIDRPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: testNamespace},
+				Spec: ipamv1alpha1.CIDRPoolSpec{
+					CIDR:                 "10.10.10.0/24",
+					PerNodeNetworkPrefix: 32,
+				},
+			}
+			Expect(k8sClient.Create(ctx, p)).NotTo(HaveOccurred())
+			p.Status.Allocations = []ipamv1alpha1.CIDRPoolAllocation{{
+				NodeName: testNodeName,
+				Prefix:   "10.10.10.12/32",
+			}}
+			Expect(k8sClient.Status().Update(ctx, p)).NotTo(HaveOccurred())
+			Eventually(func(g Gomega) {
+				g.Expect(poolManager.GetPoolByKey(
+					common.GetPoolKey("test-pool", common.PoolTypeCIDRPool))).To(
+					Equal(&pool.Pool{
+						Name:       "test-pool",
+						Subnet:     "10.10.10.12/32",
+						StartIP:    "10.10.10.12",
+						EndIP:      "10.10.10.12",
+						Exclusions: []pool.ExclusionRange{},
+						Routes:     []pool.Route{},
+					}))
+			}).WithTimeout(time.Second * 15).WithPolling(time.Second).Should(Succeed())
+		})
+		It("Update Valid config with invalid", func() {
+			p := &ipamv1alpha1.CIDRPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: testNamespace},
+				Spec: ipamv1alpha1.CIDRPoolSpec{
+					CIDR:                 "10.10.0.0/16",
+					GatewayIndex:         ptr.To[int32](1),
+					PerNodeNetworkPrefix: 24,
+				},
+			}
+			Expect(k8sClient.Create(ctx, p)).NotTo(HaveOccurred())
+			p.Status.Allocations = []ipamv1alpha1.CIDRPoolAllocation{{
+				NodeName: testNodeName,
+				Gateway:  "10.10.10.1",
+				Prefix:   "10.10.10.0/24",
+			}}
+			Expect(k8sClient.Status().Update(ctx, p)).NotTo(HaveOccurred())
+			Eventually(func(g Gomega) {
+				g.Expect(poolManager.GetPoolByKey(
+					common.GetPoolKey("test-pool", common.PoolTypeCIDRPool))).To(
+					Equal(&pool.Pool{
+						Name:       "test-pool",
+						Subnet:     "10.10.10.0/24",
+						StartIP:    "10.10.10.1",
+						EndIP:      "10.10.10.254",
+						Gateway:    "10.10.10.1",
+						Exclusions: []pool.ExclusionRange{},
+						Routes:     []pool.Route{},
+					}))
+			}).WithTimeout(time.Second * 15).WithPolling(time.Second).Should(Succeed())
+			p.Spec.GatewayIndex = ptr.To[int32](10)
+			Expect(k8sClient.Update(ctx, p)).NotTo(HaveOccurred())
+			Eventually(func(g Gomega) {
+				g.Expect(poolManager.GetPoolByKey(common.GetPoolKey("test-pool", common.PoolTypeCIDRPool))).To(BeNil())
+			}).WithTimeout(time.Second * 15).WithPolling(time.Second).Should(Succeed())
+		})
+	})
 })


### PR DESCRIPTION
Add support for single IP ranges/subnets in all places:

<details>
  <summary>IPPool perNodeBlockSize 1</summary>

```
apiVersion: nv-ipam.nvidia.com/v1alpha1
kind: IPPool
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"nv-ipam.nvidia.com/v1alpha1","kind":"IPPool","metadata":{"annotations":{},"name":"pool1","namespace":"kube-system"},"spec":{"gateway":"192.168.0.3","perNodeBlockSize":1,"subnet":"192.168.0.0/24"}}
  creationTimestamp: "2024-10-14T16:44:59Z"
  generation: 15
  name: pool1
  namespace: kube-system
  resourceVersion: "16150"
  uid: b43c059a-9364-4fbc-b945-1a1f017ddb1b
spec:
  gateway: 192.168.0.3
  perNodeBlockSize: 1
  subnet: 192.168.0.0/24
status:
  allocations:
  - endIP: 192.168.0.2
    nodeName: kind-control-plane
    startIP: 192.168.0.2
  - endIP: 192.168.0.1
    nodeName: kind-worker
    startIP: 192.168.0.1
  - endIP: 192.168.0.4
    nodeName: kind-worker2
    startIP: 192.168.0.4
  - endIP: 192.168.0.5
    nodeName: kind-worker3
    startIP: 192.168.0.5
```
</details>
<details>
  <summary>IPPool /32</summary>

```
apiVersion: nv-ipam.nvidia.com/v1alpha1
kind: IPPool
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"nv-ipam.nvidia.com/v1alpha1","kind":"IPPool","metadata":{"annotations":{},"name":"pool1","namespace":"kube-system"},"spec":{"perNodeBlockSize":1,"subnet":"192.168.1.1/32"}}
  creationTimestamp: "2024-10-14T16:44:59Z"
  generation: 16
  name: pool1
  namespace: kube-system
  resourceVersion: "16441"
  uid: b43c059a-9364-4fbc-b945-1a1f017ddb1b
spec:
  perNodeBlockSize: 1
  subnet: 192.168.1.1/32
status:
  allocations:
  - endIP: 192.168.1.1
    nodeName: kind-control-plane
    startIP: 192.168.1.1
```
</details>

</details>
<details>
  <summary>IPPool /31</summary>

```
apiVersion: nv-ipam.nvidia.com/v1alpha1
kind: IPPool
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"nv-ipam.nvidia.com/v1alpha1","kind":"IPPool","metadata":{"annotations":{},"name":"pool1","namespace":"kube-system"},"spec":{"perNodeBlockSize":1,"subnet":"192.168.1.1/31"}}
  creationTimestamp: "2024-10-14T16:44:59Z"
  generation: 17
  name: pool1
  namespace: kube-system
  resourceVersion: "16586"
  uid: b43c059a-9364-4fbc-b945-1a1f017ddb1b
spec:
  perNodeBlockSize: 1
  subnet: 192.168.1.1/31
status:
  allocations:
  - endIP: 192.168.1.1
    nodeName: kind-control-plane
    startIP: 192.168.1.1
  - endIP: 192.168.1.0
    nodeName: kind-worker
    startIP: 192.168.1.0
```
</details>

</details>
<details>
  <summary>CIDRPool /32</summary>

```
apiVersion: nv-ipam.nvidia.com/v1alpha1
kind: CIDRPool
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"nv-ipam.nvidia.com/v1alpha1","kind":"CIDRPool","metadata":{"annotations":{},"name":"pool1","namespace":"kube-system"},"spec":{"cidr":"192.168.100.0/24","perNodeNetworkPrefix":32,"staticAllocations":[{"prefix":"192.168.100.0/32"}]}}
  creationTimestamp: "2024-10-14T16:08:21Z"
  generation: 9
  name: pool1
  namespace: kube-system
  resourceVersion: "17155"
  uid: 1a90011c-e373-4ed7-bfd9-8bf1d9935a76
spec:
  cidr: 192.168.100.0/24
  perNodeNetworkPrefix: 32
  staticAllocations:
  - prefix: 192.168.100.0/32
status:
  allocations:
  - nodeName: kind-control-plane
    prefix: 192.168.100.1/32
  - nodeName: kind-worker
    prefix: 192.168.100.2/32
  - nodeName: kind-worker2
    prefix: 192.168.100.3/32
  - nodeName: kind-worker3
    prefix: 192.168.100.4/32
```
</details>

<details>
  <summary>CIDRPool /128</summary>

```
apiVersion: nv-ipam.nvidia.com/v1alpha1
kind: CIDRPool
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"nv-ipam.nvidia.com/v1alpha1","kind":"CIDRPool","metadata":{"annotations":{},"name":"pool1","namespace":"kube-system"},"spec":{"cidr":"fd52:2eb5:44::100/128","perNodeNetworkPrefix":128}}
  creationTimestamp: "2024-10-14T16:08:21Z"
  generation: 11
  name: pool1
  namespace: kube-system
  resourceVersion: "17745"
  uid: 1a90011c-e373-4ed7-bfd9-8bf1d9935a76
spec:
  cidr: fd52:2eb5:44::100/128
  perNodeNetworkPrefix: 128
status:
  allocations:
  - nodeName: kind-control-plane
    prefix: fd52:2eb5:44::100/128
```
</details>

`perNodeBlockSize: 1` - useful when you need to deploy one and only one instance of a service per node and you need to make sure that this instance is always have the same predictable IP.

`CIDRPool /32` - useful to assign IPs for loopback interfaces on routers