### PR TITLE
fix: run node as root

### DIFF
--- a/deploy/manifests/node/daemonset.yaml
+++ b/deploy/manifests/node/daemonset.yaml
@@ -62,6 +62,7 @@ spec:
                   fieldPath: spec.nodeName
           securityContext:
             privileged: true
+            runAsUser: 0
           command: [ "/ipam-node" ]
           args:
             - --node-name=$(NODE_NAME)


### PR DESCRIPTION
With new base image, node pod need to run as root in order to be able to copy the IPAM binary.