### PR TITLE
fix(ipam-node): scope Pod informer to local node

### DIFF
--- a/cmd/ipam-node/app/app.go
+++ b/cmd/ipam-node/app/app.go
@@ -32,6 +32,7 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -151,7 +152,11 @@ func RunNodeDaemon(ctx context.Context, config *rest.Config, opts *options.Optio
 		Cache: cache.Options{
 			DefaultNamespaces: map[string]cache.Config{opts.PoolsNamespace: {}},
 			ByObject: map[client.Object]cache.ByObject{
-				&corev1.Pod{}: {Namespaces: map[string]cache.Config{cache.AllNamespaces: {}}}},
+				&corev1.Pod{}: {
+					Namespaces: map[string]cache.Config{cache.AllNamespaces: {}},
+					Field:      fields.OneTermEqualSelector("spec.nodeName", opts.NodeName),
+				},
+			},
 		},
 	})
 	if err != nil {

--- a/pkg/ipam-node/store/store.go
+++ b/pkg/ipam-node/store/store.go
@@ -166,7 +166,7 @@ func (s *session) Commit() error {
 		s.log.Error(err, "failed to write data to disk")
 		return err
 	}
-	*s.persistedData = *s.tmpData.DeepCopy()
+	*s.persistedData = *s.tmpData
 	return nil
 }
 


### PR DESCRIPTION
The Pod cache was watching the whole cluster, causing memory to scale with cluster size and producing sawtooth spikes near the 300 MB limit on large clusters. The only consumer (cleaner) looks up pods by name and already falls back to the direct API client on cache miss, so a spec.nodeName field selector is safe and cuts steady-state cache memory to O(local-node pods).

Also drop a redundant DeepCopy in session.Commit(): the store mutex guarantees no concurrent reader, and the next Open re-seeds tmpData, so the extra copy of the reservations map per write is unnecessary.