### PR TITLE
fix: handle large IPv6 address ranges

### DIFF
--- a/api/v1alpha1/helpers.go
+++ b/api/v1alpha1/helpers.go
@@ -43,8 +43,8 @@ func GetGatewayForSubnet(subnet *net.IPNet, index int32) string {
 		// index too large
 		return ""
 	}
-	gwIP := ip.NextIPWithOffset(subnet.IP, int64(index))
-	if gwIP == nil {
+	gwIP, err := ip.NextIPWithOffset(subnet.IP, big.NewInt(int64(index)))
+	if err != nil {
 		return ""
 	}
 	return gwIP.String()
@@ -87,12 +87,12 @@ func ExcludeIndexRangeToExcludeRange(excludeIndexRanges []ExcludeIndexRange, sta
 
 	excludeRanges := make([]ExcludeRange, 0, len(excludeIndexRanges))
 	for _, excludeIndexRange := range excludeIndexRanges {
-		excludeRangeStart := ip.NextIPWithOffset(rangeStart, int64(excludeIndexRange.StartIndex))
-		if excludeRangeStart == nil {
+		excludeRangeStart, err := ip.NextIPWithOffset(rangeStart, big.NewInt(int64(excludeIndexRange.StartIndex)))
+		if err != nil {
 			continue
 		}
-		excludeRangeEnd := ip.NextIPWithOffset(rangeStart, int64(excludeIndexRange.EndIndex))
-		if excludeRangeEnd == nil {
+		excludeRangeEnd, err := ip.NextIPWithOffset(rangeStart, big.NewInt(int64(excludeIndexRange.EndIndex)))
+		if err != nil {
 			continue
 		}
 
@@ -101,6 +101,40 @@ func ExcludeIndexRangeToExcludeRange(excludeIndexRanges []ExcludeIndexRange, sta
 	}
 
 	return excludeRanges
+}
+
+// ExcludeIndexRangesCover reports whether exclusions cover every index from zero through lastIndex, inclusive.
+func ExcludeIndexRangesCover(exclusions []ExcludeIndexRange, lastIndex *big.Int) bool {
+	if lastIndex == nil || lastIndex.Sign() < 0 || len(exclusions) == 0 {
+		return false
+	}
+
+	ranges := append([]ExcludeIndexRange(nil), exclusions...)
+	sort.Slice(ranges, func(i, j int) bool {
+		if ranges[i].StartIndex == ranges[j].StartIndex {
+			return ranges[i].EndIndex < ranges[j].EndIndex
+		}
+		return ranges[i].StartIndex < ranges[j].StartIndex
+	})
+
+	coveredThrough := big.NewInt(-1)
+	for _, excludeRange := range ranges {
+		if excludeRange.StartIndex < 0 || excludeRange.EndIndex < excludeRange.StartIndex {
+			return false
+		}
+		nextUncovered := new(big.Int).Add(coveredThrough, big.NewInt(1))
+		if big.NewInt(int64(excludeRange.StartIndex)).Cmp(nextUncovered) > 0 {
+			return false
+		}
+		end := big.NewInt(int64(excludeRange.EndIndex))
+		if end.Cmp(coveredThrough) > 0 {
+			coveredThrough.Set(end)
+		}
+		if coveredThrough.Cmp(lastIndex) >= 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // ClampExcludeRange clamps the exclusion range to the provided startIP and endIP range.

--- a/api/v1alpha1/helpers_test.go
+++ b/api/v1alpha1/helpers_test.go
@@ -14,6 +14,7 @@
 package v1alpha1_test
 
 import (
+	"math/big"
 	"net"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -23,6 +24,24 @@ import (
 )
 
 var _ = Describe("Helpers", func() {
+	DescribeTable("ExcludeIndexRangesCover",
+		func(exclusions []v1alpha1.ExcludeIndexRange, lastIndex int64, expected bool) {
+			Expect(v1alpha1.ExcludeIndexRangesCover(exclusions, big.NewInt(lastIndex))).To(Equal(expected))
+		},
+		Entry("single covering range", []v1alpha1.ExcludeIndexRange{{StartIndex: 0, EndIndex: 15}}, int64(15), true),
+		Entry("adjacent ranges", []v1alpha1.ExcludeIndexRange{
+			{StartIndex: 8, EndIndex: 15}, {StartIndex: 0, EndIndex: 7},
+		}, int64(15), true),
+		Entry("overlapping ranges", []v1alpha1.ExcludeIndexRange{
+			{StartIndex: 0, EndIndex: 8}, {StartIndex: 4, EndIndex: 15},
+		}, int64(15), true),
+		Entry("gap", []v1alpha1.ExcludeIndexRange{
+			{StartIndex: 0, EndIndex: 7}, {StartIndex: 9, EndIndex: 15},
+		}, int64(15), false),
+		Entry("does not start at zero", []v1alpha1.ExcludeIndexRange{{StartIndex: 1, EndIndex: 15}}, int64(15), false),
+		Entry("range is too short", []v1alpha1.ExcludeIndexRange{{StartIndex: 0, EndIndex: 14}}, int64(15), false),
+	)
+
 	DescribeTable("GetGatewayForSubnet",
 		func(subnet string, index int, gw string) {
 			_, network, err := net.ParseCIDR(subnet)

--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -16,6 +16,7 @@ package ip
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math/big"
 	"net"
 )
@@ -31,18 +32,22 @@ func NextIP(ip net.IP) net.IP {
 	return intToIP(i.Add(i, big.NewInt(1)), len(normalizedIP) == net.IPv6len)
 }
 
-// NextIPWithOffset returns IP incremented by offset, if IP is invalid, return nil
-func NextIPWithOffset(ip net.IP, offset int64) net.IP {
-	if offset < 0 {
-		return nil
+// NextIPWithOffset returns IP incremented by offset.
+func NextIPWithOffset(ip net.IP, offset *big.Int) (net.IP, error) {
+	if offset == nil || offset.Sign() < 0 {
+		return nil, fmt.Errorf("offset must be non-negative")
 	}
 	normalizedIP := NormalizeIP(ip)
 	if normalizedIP == nil {
-		return nil
+		return nil, fmt.Errorf("invalid IP address")
 	}
 
 	i := ipToInt(normalizedIP)
-	return intToIP(i.Add(i, big.NewInt(offset)), len(normalizedIP) == net.IPv6len)
+	nextIP := intToIP(i.Add(i, offset), len(normalizedIP) == net.IPv6len)
+	if nextIP == nil {
+		return nil, fmt.Errorf("IP address overflow")
+	}
+	return nextIP, nil
 }
 
 // PrevIP returns IP decremented by 1, if IP is invalid, return nil
@@ -72,24 +77,22 @@ func Cmp(a, b net.IP) int {
 	return -2
 }
 
-// Distance returns amount of IPs between a and b
-// returns -1 if result is negative
-// returns -2 if result is too large or IPs are not valid addresses
-func Distance(a, b net.IP) int64 {
+// Distance returns the non-negative distance between two addresses of the same family.
+func Distance(a, b net.IP) (*big.Int, error) {
 	normalizedA := NormalizeIP(a)
 	normalizedB := NormalizeIP(b)
-
-	if len(normalizedA) == len(normalizedB) && len(normalizedA) != 0 {
-		count := big.NewInt(0).Sub(ipToInt(normalizedB), ipToInt(normalizedA))
-		if !count.IsInt64() {
-			return -2
-		}
-		if count.Sign() < 0 {
-			return -1
-		}
-		return count.Int64()
+	if len(normalizedA) == 0 || len(normalizedB) == 0 {
+		return nil, fmt.Errorf("invalid IP address")
 	}
-	return -2
+	if len(normalizedA) != len(normalizedB) {
+		return nil, fmt.Errorf("IP address families do not match")
+	}
+
+	distance := new(big.Int).Sub(ipToInt(normalizedB), ipToInt(normalizedA))
+	if distance.Sign() < 0 {
+		return nil, fmt.Errorf("second IP address must not precede first IP address")
+	}
+	return distance, nil
 }
 
 func ipToInt(ip net.IP) *big.Int {
@@ -177,42 +180,103 @@ func LastIP(network *net.IPNet) net.IP {
 	return end
 }
 
-// GetSubnetGen returns generator function that can be called multiple times
-// to generate subnet for the network with the prefix size.
-// The function always returns non-nil function.
-// The generator function will return nil If subnet can't be generate
-// (invalid input args provided, or no more subnets available for the network).
-// Example:
-// _, network, _ := net.ParseCIDR("192.168.0.0/23")
-// gen := GetSubnetGen(network, 25)
-// println(gen().String()) // 192.168.0.0/25
-// println(gen().String()) // 192.168.0.128/25
-// println(gen().String()) // 192.168.1.0/25
-// println(gen().String()) // 192.168.1.128/25
-// println(gen().String()) // <nil> - no more ranges available
-func GetSubnetGen(network *net.IPNet, prefixSize int32) func() *net.IPNet {
+// SubnetIterator iterates over fixed-size prefixes in a network and can skip large address intervals in constant time.
+type SubnetIterator struct {
+	isIPv6         bool
+	netBitsTotal   int
+	prefixSize     int32
+	networkIPAsInt *big.Int
+	subnetIPCount  *big.Int
+	subnetCount    *big.Int
+	nextIndex      *big.Int
+}
+
+// NewSubnetIterator creates an iterator over prefixSize subnets in network.
+func NewSubnetIterator(network *net.IPNet, prefixSize int32) (*SubnetIterator, error) {
+	if network == nil {
+		return nil, fmt.Errorf("network must not be nil")
+	}
 	networkOnes, netBitsTotal := network.Mask.Size()
+	if netBitsTotal != net.IPv4len*8 && netBitsTotal != net.IPv6len*8 {
+		return nil, fmt.Errorf("network mask must be a valid IPv4 or IPv6 mask")
+	}
 	//nolint: gosec
 	if prefixSize < int32(networkOnes) || prefixSize > int32(netBitsTotal) {
-		return func() *net.IPNet { return nil }
+		return nil, fmt.Errorf("prefix size must be between %d and %d", networkOnes, netBitsTotal)
 	}
-	isIPv6 := network.IP.To4() == nil
-	networkIPAsInt := ipToInt(network.IP)
-	subnetIPCount := big.NewInt(0).Exp(big.NewInt(2), big.NewInt(int64(netBitsTotal)-int64(prefixSize)), nil)
-	subnetCount := big.NewInt(0).Exp(big.NewInt(2), big.NewInt(int64(prefixSize)-int64(networkOnes)), nil)
 
-	curSubnetIndex := big.NewInt(0)
-
-	return func() *net.IPNet {
-		if curSubnetIndex.Cmp(subnetCount) >= 0 {
-			return nil
-		}
-		subnetIPAsInt := big.NewInt(0).Add(networkIPAsInt, big.NewInt(0).Mul(subnetIPCount, curSubnetIndex))
-		curSubnetIndex.Add(curSubnetIndex, big.NewInt(1))
-		subnetIP := intToIP(subnetIPAsInt, isIPv6)
-		if subnetIP == nil {
-			return nil
-		}
-		return &net.IPNet{IP: subnetIP, Mask: net.CIDRMask(int(prefixSize), netBitsTotal)}
+	var normalizedNetworkIP net.IP
+	if netBitsTotal == net.IPv4len*8 {
+		normalizedNetworkIP = network.IP.To4()
+	} else if network.IP.To4() == nil {
+		normalizedNetworkIP = network.IP.To16()
 	}
+	if normalizedNetworkIP == nil {
+		return nil, fmt.Errorf("network IP address does not match the mask")
+	}
+	if !normalizedNetworkIP.Equal(normalizedNetworkIP.Mask(network.Mask)) {
+		return nil, fmt.Errorf("network IP address has host bits set")
+	}
+
+	return &SubnetIterator{
+		isIPv6:         netBitsTotal == net.IPv6len*8,
+		netBitsTotal:   netBitsTotal,
+		prefixSize:     prefixSize,
+		networkIPAsInt: new(big.Int).SetBytes(normalizedNetworkIP),
+		subnetIPCount:  new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(netBitsTotal)-int64(prefixSize)), nil),
+		subnetCount:    new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(prefixSize)-int64(networkOnes)), nil),
+		nextIndex:      big.NewInt(0),
+	}, nil
+}
+
+// Next returns the next prefix, or nil after the iterator is exhausted.
+func (i *SubnetIterator) Next() *net.IPNet {
+	if i == nil || i.nextIndex.Cmp(i.subnetCount) >= 0 {
+		return nil
+	}
+	subnetOffset := new(big.Int).Mul(i.subnetIPCount, i.nextIndex)
+	subnetIPAsInt := new(big.Int).Add(i.networkIPAsInt, subnetOffset)
+	i.nextIndex.Add(i.nextIndex, big.NewInt(1))
+	subnetIP := intToIP(subnetIPAsInt, i.isIPv6)
+	if subnetIP == nil {
+		return nil
+	}
+	return &net.IPNet{IP: subnetIP, Mask: net.CIDRMask(int(i.prefixSize), i.netBitsTotal)}
+}
+
+// AdvancePastIP moves the iterator to the prefix containing the address immediately after end.
+// It never moves the iterator backwards. If end is the last address or beyond the iterator network, the iterator is
+// exhausted.
+func (i *SubnetIterator) AdvancePastIP(end net.IP) error {
+	if i == nil {
+		return fmt.Errorf("invalid subnet iterator")
+	}
+	var normalizedEnd net.IP
+	if i.isIPv6 {
+		if end.To4() == nil {
+			normalizedEnd = end.To16()
+		}
+	} else {
+		normalizedEnd = end.To4()
+	}
+	if normalizedEnd == nil {
+		return fmt.Errorf("IP address family does not match iterator network")
+	}
+	nextIP := NextIP(normalizedEnd)
+	if nextIP == nil {
+		i.nextIndex.Set(i.subnetCount)
+		return nil
+	}
+	distance := new(big.Int).Sub(ipToInt(nextIP), i.networkIPAsInt)
+	if distance.Sign() < 0 {
+		return nil
+	}
+	targetIndex := new(big.Int).Quo(distance, i.subnetIPCount)
+	if targetIndex.Cmp(i.nextIndex) > 0 {
+		i.nextIndex.Set(targetIndex)
+	}
+	if i.nextIndex.Cmp(i.subnetCount) > 0 {
+		i.nextIndex.Set(i.subnetCount)
+	}
+	return nil
 }

--- a/pkg/ip/cidr_test.go
+++ b/pkg/ip/cidr_test.go
@@ -15,6 +15,7 @@
 package ip
 
 import (
+	"math/big"
 	"net"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -69,92 +70,147 @@ var _ = Describe("CIDR functions", func() {
 
 	It("NextIPWithOffset", func() {
 		testCases := []struct {
-			ip     net.IP
-			offset int64
-			nextIP net.IP
+			ip          net.IP
+			offset      *big.Int
+			nextIP      net.IP
+			expectError bool
 		}{
 			{
 				[]byte{192, 0, 2},
-				10,
+				big.NewInt(10),
 				nil,
+				true,
 			},
 			{
 				net.ParseIP("192.168.0.1"),
-				10,
+				big.NewInt(10),
 				net.IPv4(192, 168, 0, 11).To4(),
+				false,
 			},
 			{
 				net.ParseIP("192.168.0.254"),
-				10,
+				big.NewInt(10),
 				net.IPv4(192, 168, 1, 8).To4(),
+				false,
 			},
 			{
 				net.ParseIP("192.168.0.254"),
-				-10,
+				big.NewInt(-10),
 				nil,
+				true,
 			},
 			{
 				net.ParseIP("0::123"),
-				3,
+				big.NewInt(3),
 				net.ParseIP("0::126"),
+				false,
 			},
 			{
 				net.ParseIP("AB12::FFFF"),
-				3,
+				big.NewInt(3),
 				net.ParseIP("AB12::1:2"),
+				false,
+			},
+			{
+				net.ParseIP("192.168.0.1"),
+				nil,
+				nil,
+				true,
 			},
 		}
 
 		for _, test := range testCases {
-			ip := NextIPWithOffset(test.ip, test.offset)
+			nextIP, err := NextIPWithOffset(test.ip, test.offset)
+			if test.expectError {
+				Expect(err).To(HaveOccurred())
+				Expect(nextIP).To(BeNil())
+				continue
+			}
 
-			Expect(ip).To(Equal(test.nextIP))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nextIP).To(Equal(test.nextIP))
 		}
 	})
 
 	It("Distance", func() {
 		testCases := []struct {
-			ipA   net.IP
-			ipB   net.IP
-			count int64
+			ipA         net.IP
+			ipB         net.IP
+			count       int64
+			expectError bool
 		}{
 			{
 				net.ParseIP("192.168.0.1"),
 				net.ParseIP("192.168.0.11"),
 				10,
+				false,
 			},
 			{
 				net.ParseIP("192.168.0.2"),
 				net.ParseIP("192.168.0.2"),
 				0,
+				false,
 			},
 			{
 				net.ParseIP("AB12::FFFF"),
 				net.ParseIP("AB12::1:2"),
 				3,
+				false,
 			},
 			{
 				net.ParseIP("192.168.0.11"),
 				net.ParseIP("192.168.0.1"),
-				-1,
+				0,
+				true,
 			},
 			{
 				net.ParseIP("192.168.0.11"),
 				[]byte{192, 0, 2},
-				-2,
+				0,
+				true,
 			},
 			{
 				net.ParseIP("192.168.0.11"),
 				net.ParseIP("AB12::FFFF"),
-				-2,
+				0,
+				true,
 			},
 		}
 
 		for _, test := range testCases {
-			ip := Distance(test.ipA, test.ipB)
+			distance, err := Distance(test.ipA, test.ipB)
+			if test.expectError {
+				Expect(err).To(HaveOccurred())
+				Expect(distance).To(BeNil())
+				continue
+			}
 
-			Expect(ip).To(Equal(test.count))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(distance.Cmp(big.NewInt(test.count))).To(BeZero())
 		}
+	})
+
+	It("Distance and NextIPWithOffset support distances larger than int64", func() {
+		start := net.ParseIP("2001:db8::11")
+		end := net.ParseIP("2001:db8:0:1::11")
+		expected := new(big.Int).Lsh(big.NewInt(1), 64)
+
+		distance, err := Distance(start, end)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(distance).To(Equal(expected))
+
+		result, err := NextIPWithOffset(start, distance)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(end))
+	})
+
+	It("exact address arithmetic rejects invalid operations", func() {
+		_, err := Distance(net.ParseIP("2001:db8::1"), net.ParseIP("192.0.2.1"))
+		Expect(err).To(HaveOccurred())
+		_, err = Distance(net.ParseIP("2001:db8::2"), net.ParseIP("2001:db8::1"))
+		Expect(err).To(HaveOccurred())
+		_, err = NextIPWithOffset(net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"), big.NewInt(1))
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("PrevIP", func() {
@@ -336,82 +392,133 @@ var _ = Describe("CIDR functions", func() {
 		}
 	})
 
-	Context("GetSubnetGen", func() {
-		It("Invalid args - prefix is larger then network", func() {
-			_, net, _ := net.ParseCIDR("192.168.0.0/16")
-			gen := GetSubnetGen(net, 8)
-			Expect(gen).NotTo(BeNil())
-			Expect(gen()).To(BeNil())
+	Context("NewSubnetIterator", func() {
+		It("rejects a prefix shorter than the network prefix", func() {
+			_, network, err := net.ParseCIDR("192.168.0.0/16")
+			Expect(err).NotTo(HaveOccurred())
+			iterator, err := NewSubnetIterator(network, 8)
+			Expect(err).To(HaveOccurred())
+			Expect(iterator).To(BeNil())
 		})
-		It("Invalid args - prefix is too small for IPv4", func() {
-			_, net, _ := net.ParseCIDR("192.168.0.0/16")
-			gen := GetSubnetGen(net, 120)
-			Expect(gen).NotTo(BeNil())
-			Expect(gen()).To(BeNil())
+		It("rejects a prefix longer than the address width", func() {
+			_, network, err := net.ParseCIDR("192.168.0.0/16")
+			Expect(err).NotTo(HaveOccurred())
+			iterator, err := NewSubnetIterator(network, 120)
+			Expect(err).To(HaveOccurred())
+			Expect(iterator).To(BeNil())
+		})
+		It("rejects invalid network input", func() {
+			iterator, err := NewSubnetIterator(nil, 24)
+			Expect(err).To(HaveOccurred())
+			Expect(iterator).To(BeNil())
+
+			iterator, err = NewSubnetIterator(&net.IPNet{
+				IP:   net.ParseIP("192.168.0.0"),
+				Mask: net.IPMask{0xff, 0x00, 0xff, 0x00},
+			}, 24)
+			Expect(err).To(HaveOccurred())
+			Expect(iterator).To(BeNil())
+		})
+		It("rejects an IP address that does not match the mask family", func() {
+			iterator, err := NewSubnetIterator(&net.IPNet{
+				IP:   net.ParseIP("2001:db8::"),
+				Mask: net.CIDRMask(24, 32),
+			}, 24)
+			Expect(err).To(HaveOccurred())
+			Expect(iterator).To(BeNil())
 		})
 		It("Valid - single subnet IPv4", func() {
-			_, net, _ := net.ParseCIDR("192.168.0.0/24")
-			gen := GetSubnetGen(net, 24)
-			Expect(gen).NotTo(BeNil())
-			Expect(gen().String()).To(Equal("192.168.0.0/24"))
-			Expect(gen()).To(BeNil())
+			_, network, err := net.ParseCIDR("192.168.0.0/24")
+			Expect(err).NotTo(HaveOccurred())
+			iterator, err := NewSubnetIterator(network, 24)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(iterator.Next().String()).To(Equal("192.168.0.0/24"))
+			Expect(iterator.Next()).To(BeNil())
 		})
 		It("Valid - single subnet IPv6", func() {
-			_, net, _ := net.ParseCIDR("2002:0:0:1234::/64")
-			gen := GetSubnetGen(net, 64)
-			Expect(gen).NotTo(BeNil())
-			Expect(gen().String()).To(Equal("2002:0:0:1234::/64"))
-			Expect(gen()).To(BeNil())
+			_, network, err := net.ParseCIDR("2002:0:0:1234::/64")
+			Expect(err).NotTo(HaveOccurred())
+			iterator, err := NewSubnetIterator(network, 64)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(iterator.Next().String()).To(Equal("2002:0:0:1234::/64"))
+			Expect(iterator.Next()).To(BeNil())
 		})
 		It("valid - IPv4", func() {
-			_, net, _ := net.ParseCIDR("192.168.4.0/23")
-			gen := GetSubnetGen(net, 25)
-			Expect(gen).NotTo(BeNil())
-			Expect(gen().String()).To(Equal("192.168.4.0/25"))
-			Expect(gen().String()).To(Equal("192.168.4.128/25"))
-			Expect(gen().String()).To(Equal("192.168.5.0/25"))
-			Expect(gen().String()).To(Equal("192.168.5.128/25"))
-			Expect(gen()).To(BeNil())
+			_, network, err := net.ParseCIDR("192.168.4.0/23")
+			Expect(err).NotTo(HaveOccurred())
+			iterator, err := NewSubnetIterator(network, 25)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(iterator.Next().String()).To(Equal("192.168.4.0/25"))
+			Expect(iterator.Next().String()).To(Equal("192.168.4.128/25"))
+			Expect(iterator.Next().String()).To(Equal("192.168.5.0/25"))
+			Expect(iterator.Next().String()).To(Equal("192.168.5.128/25"))
+			Expect(iterator.Next()).To(BeNil())
 		})
 		It("valid - IPv6", func() {
-			_, net, _ := net.ParseCIDR("2002:0:0:1234::/64")
-			gen := GetSubnetGen(net, 124)
-			Expect(gen).NotTo(BeNil())
-			Expect(gen().String()).To(Equal("2002:0:0:1234::/124"))
-			Expect(gen().String()).To(Equal("2002:0:0:1234::10/124"))
-			Expect(gen().String()).To(Equal("2002:0:0:1234::20/124"))
+			_, network, err := net.ParseCIDR("2002:0:0:1234::/64")
+			Expect(err).NotTo(HaveOccurred())
+			iterator, err := NewSubnetIterator(network, 124)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(iterator.Next().String()).To(Equal("2002:0:0:1234::/124"))
+			Expect(iterator.Next().String()).To(Equal("2002:0:0:1234::10/124"))
+			Expect(iterator.Next().String()).To(Equal("2002:0:0:1234::20/124"))
 		})
 		It("valid - large IPv6 subnet (overflow test)", func() {
-			_, net, _ := net.ParseCIDR("::/0")
-			gen := GetSubnetGen(net, 127)
-			Expect(gen).NotTo(BeNil())
-			Expect(gen().String()).To(Equal("::/127"))
-			Expect(gen().String()).To(Equal("::2/127"))
-			Expect(gen().String()).To(Equal("::4/127"))
+			_, network, err := net.ParseCIDR("::/0")
+			Expect(err).NotTo(HaveOccurred())
+			iterator, err := NewSubnetIterator(network, 127)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(iterator.Next().String()).To(Equal("::/127"))
+			Expect(iterator.Next().String()).To(Equal("::2/127"))
+			Expect(iterator.Next().String()).To(Equal("::4/127"))
 		})
 		It("valid - single IP IPv4 subnet", func() {
-			_, net, _ := net.ParseCIDR("192.168.0.0/16")
-			gen := GetSubnetGen(net, 32)
-			Expect(gen).NotTo(BeNil())
-			Expect(gen().String()).To(Equal("192.168.0.0/32"))
-			Expect(gen().String()).To(Equal("192.168.0.1/32"))
-			Expect(gen().String()).To(Equal("192.168.0.2/32"))
+			_, network, err := net.ParseCIDR("192.168.0.0/16")
+			Expect(err).NotTo(HaveOccurred())
+			iterator, err := NewSubnetIterator(network, 32)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(iterator.Next().String()).To(Equal("192.168.0.0/32"))
+			Expect(iterator.Next().String()).To(Equal("192.168.0.1/32"))
+			Expect(iterator.Next().String()).To(Equal("192.168.0.2/32"))
 		})
 		It("valid - single IP IPv6 subnet", func() {
-			_, net, _ := net.ParseCIDR("2002:0:0:1234::/64")
-			gen := GetSubnetGen(net, 128)
-			Expect(gen).NotTo(BeNil())
-			Expect(gen().String()).To(Equal("2002:0:0:1234::/128"))
-			Expect(gen().String()).To(Equal("2002:0:0:1234::1/128"))
-			Expect(gen().String()).To(Equal("2002:0:0:1234::2/128"))
+			_, network, err := net.ParseCIDR("2002:0:0:1234::/64")
+			Expect(err).NotTo(HaveOccurred())
+			iterator, err := NewSubnetIterator(network, 128)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(iterator.Next().String()).To(Equal("2002:0:0:1234::/128"))
+			Expect(iterator.Next().String()).To(Equal("2002:0:0:1234::1/128"))
+			Expect(iterator.Next().String()).To(Equal("2002:0:0:1234::2/128"))
 		})
 		It("valid - single IP IPv4 subnet, point to point network", func() {
-			_, net, _ := net.ParseCIDR("192.168.0.0/31")
-			gen := GetSubnetGen(net, 32)
-			Expect(gen).NotTo(BeNil())
-			Expect(gen().String()).To(Equal("192.168.0.0/32"))
-			Expect(gen().String()).To(Equal("192.168.0.1/32"))
-			Expect(gen()).To(BeNil())
+			_, network, err := net.ParseCIDR("192.168.0.0/31")
+			Expect(err).NotTo(HaveOccurred())
+			iterator, err := NewSubnetIterator(network, 32)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(iterator.Next().String()).To(Equal("192.168.0.0/32"))
+			Expect(iterator.Next().String()).To(Equal("192.168.0.1/32"))
+			Expect(iterator.Next()).To(BeNil())
+		})
+	})
+	Context("SubnetIterator.AdvancePastIP", func() {
+		It("advances across an exhausted IPv6 /64 in constant time", func() {
+			_, network, err := net.ParseCIDR("2001:db8::/64")
+			Expect(err).NotTo(HaveOccurred())
+			iterator, err := NewSubnetIterator(network, 128)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(iterator.Next().String()).To(Equal("2001:db8::/128"))
+			Expect(iterator.AdvancePastIP(net.ParseIP("2001:db8::ffff:ffff:ffff:ffff"))).To(Succeed())
+			Expect(iterator.Next()).To(BeNil())
+		})
+
+		It("reevaluates the prefix containing an exclusion boundary", func() {
+			_, network, err := net.ParseCIDR("2001:db8::/120")
+			Expect(err).NotTo(HaveOccurred())
+			iterator, err := NewSubnetIterator(network, 124)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(iterator.Next().String()).To(Equal("2001:db8::/124"))
+			Expect(iterator.AdvancePastIP(net.ParseIP("2001:db8::24"))).To(Succeed())
+			Expect(iterator.Next().String()).To(Equal("2001:db8::20/124"))
 		})
 	})
 	Context("IsPointToPointSubnet", func() {

--- a/pkg/ipam-controller/allocator/allocator.go
+++ b/pkg/ipam-controller/allocator/allocator.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
+	"math/big"
 	"net"
 	"reflect"
 
@@ -83,6 +83,15 @@ func (pa *PoolAllocator) AllocateFromPool(ctx context.Context, node string) (*Al
 			"start", existingAlloc.StartIP, "end", existingAlloc.EndIP)
 		return &existingAlloc, nil
 	}
+	if pa.cfg.PerNodeBlockSize <= 0 {
+		return &AllocatedRange{}, fmt.Errorf("per-node block size must be positive")
+	}
+	blockSize := big.NewInt(int64(pa.cfg.PerNodeBlockSize))
+	lastBlockIndex := new(big.Int).Sub(new(big.Int).Set(blockSize), big.NewInt(1))
+	if ipamv1alpha1.ExcludeIndexRangesCover(pa.cfg.PerNodeExclusions, lastBlockIndex) {
+		log.Info("can't allocate: every per-node block is fully excluded")
+		return &AllocatedRange{}, ErrNoFreeRanges
+	}
 
 	// determine the next possible range for the subnet
 	var startIP net.IP
@@ -91,28 +100,35 @@ func (pa *PoolAllocator) AllocateFromPool(ctx context.Context, node string) (*Al
 	if pa.lastAllocatedStartIP == nil {
 		startIP = pa.getFirstStartIP()
 	} else {
-		startIP = ip.NextIPWithOffset(pa.lastAllocatedStartIP, int64(pa.cfg.PerNodeBlockSize))
+		startIP = nextIPWithOffsetOrNil(pa.lastAllocatedStartIP, blockSize)
 	}
-	endIP = ip.NextIPWithOffset(startIP, int64(pa.cfg.PerNodeBlockSize)-1)
+	endIP = nextIPWithOffsetOrNil(startIP, lastBlockIndex)
 
 	for pa.allocationValid(startIP, endIP) {
+		if err := ctx.Err(); err != nil {
+			return &AllocatedRange{}, err
+		}
 		// check if the range is allocated i.e its present in startIPs
 		if pa.startIps.Has(startIP.String()) {
 			startIP = ip.NextIP(endIP)
-			endIP = ip.NextIPWithOffset(startIP, int64(pa.cfg.PerNodeBlockSize)-1)
+			endIP = nextIPWithOffsetOrNil(startIP, lastBlockIndex)
 			continue
 		}
 
 		// check if the entire range is excluded
 		if pa.isEntireRangeExcluded(AllocatedRange{StartIP: startIP, EndIP: endIP}) {
-			startIP, endIP = pa.getNextNonExcludedCandidates(startIP, endIP)
+			var err error
+			startIP, endIP, err = pa.getNextNonExcludedCandidates(startIP, endIP)
+			if err != nil {
+				return &AllocatedRange{}, fmt.Errorf("failed to skip excluded range: %w", err)
+			}
 			continue
 		}
 
 		// if perNodeBlockSize is 1, we should not allocate the gateway
 		if pa.cfg.PerNodeBlockSize == 1 && pa.cfg.Gateway != nil && startIP.Equal(pa.cfg.Gateway) {
 			startIP = ip.NextIP(endIP)
-			endIP = ip.NextIPWithOffset(startIP, int64(pa.cfg.PerNodeBlockSize)-1)
+			endIP = nextIPWithOffsetOrNil(startIP, lastBlockIndex)
 			continue
 		}
 
@@ -138,17 +154,28 @@ func (pa *PoolAllocator) AllocateFromPool(ctx context.Context, node string) (*Al
 	return &a, nil
 }
 
+func nextIPWithOffsetOrNil(address net.IP, offset *big.Int) net.IP {
+	nextIP, err := ip.NextIPWithOffset(address, offset)
+	if err != nil {
+		return nil
+	}
+	return nextIP
+}
+
 // getNextNonExcludedCandidates returns the next non excluded start and end IP candidates
-func (pa *PoolAllocator) getNextNonExcludedCandidates(currentStartIP net.IP, currentEndIP net.IP) (net.IP, net.IP) {
+func (pa *PoolAllocator) getNextNonExcludedCandidates(
+	currentStartIP net.IP, currentEndIP net.IP,
+) (net.IP, net.IP, error) {
 	if currentStartIP == nil || currentEndIP == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// the next start and end IP candidates start from currentEndIP +1
 	nextStartIP := ip.NextIP(currentEndIP)
-	nextEndIP := ip.NextIPWithOffset(nextStartIP, int64(pa.cfg.PerNodeBlockSize)-1)
+	lastBlockIndex := big.NewInt(int64(pa.cfg.PerNodeBlockSize) - 1)
+	nextEndIP := nextIPWithOffsetOrNil(nextStartIP, lastBlockIndex)
 	if nextStartIP == nil || nextEndIP == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// merge exclude ranges
@@ -164,21 +191,29 @@ func (pa *PoolAllocator) getNextNonExcludedCandidates(currentStartIP net.IP, cur
 		// that IP is for sure not excluded because if it was, it would have been included in the merged exclude ranges.
 		nextFreeIP := ip.NextIP(net.ParseIP(excludeRange.EndIP))
 		if nextFreeIP == nil {
-			return nil, nil
+			return nil, nil, nil
 		}
 
 		// align it to the nearest block size boundary and return the next candidate start and end IPs
-		distance := ip.Distance(nextStartIP, nextFreeIP)
-		ipsToSkip := (distance / int64(pa.cfg.PerNodeBlockSize)) * int64(pa.cfg.PerNodeBlockSize)
+		distance, err := ip.Distance(nextStartIP, nextFreeIP)
+		if err != nil {
+			return nil, nil, err
+		}
+		blockSize := big.NewInt(int64(pa.cfg.PerNodeBlockSize))
+		blocksToSkip := new(big.Int).Quo(distance, blockSize)
+		ipsToSkip := new(big.Int).Mul(blocksToSkip, blockSize)
 
-		nextStartIP = ip.NextIPWithOffset(nextStartIP, ipsToSkip)
-		nextEndIP = ip.NextIPWithOffset(nextStartIP, int64(pa.cfg.PerNodeBlockSize)-1)
-		return nextStartIP, nextEndIP
+		nextStartIP, err = ip.NextIPWithOffset(nextStartIP, ipsToSkip)
+		if err != nil {
+			return nil, nil, err
+		}
+		nextEndIP = nextIPWithOffsetOrNil(nextStartIP, lastBlockIndex)
+		return nextStartIP, nextEndIP, nil
 	}
 
 	// if we reach this point then startIP and endIP are not fully contained in any of the exclude ranges
 	// so they can be used as candidates for allocation
-	return nextStartIP, nextEndIP
+	return nextStartIP, nextEndIP, nil
 }
 
 // allocationValid checks if the allocation is valid
@@ -220,27 +255,43 @@ func (pa *PoolAllocator) load(ctx context.Context, nodeName string, allocRange A
 }
 
 func (pa *PoolAllocator) checkAllocation(allocRange AllocatedRange) error {
+	if pa.cfg.PerNodeBlockSize <= 0 {
+		return fmt.Errorf("per-node block size must be positive")
+	}
 	if !pa.cfg.Subnet.Contains(allocRange.StartIP) || !pa.cfg.Subnet.Contains(allocRange.EndIP) {
 		return fmt.Errorf("invalid allocation allocators: start or end IP is out of the subnet")
 	}
 	if ip.Cmp(allocRange.EndIP, allocRange.StartIP) < 0 {
 		return fmt.Errorf("invalid allocation allocators: start IP must be less or equal to end IP")
 	}
-	distanceFromNetworkStart := ip.Distance(pa.cfg.Subnet.IP, allocRange.StartIP)
+	distanceFromNetworkStart, err := ip.Distance(pa.cfg.Subnet.IP, allocRange.StartIP)
+	if err != nil {
+		return fmt.Errorf("failed to calculate allocation offset: %w", err)
+	}
+	blockSize := big.NewInt(int64(pa.cfg.PerNodeBlockSize))
+	allocationOffset := new(big.Int).Set(distanceFromNetworkStart)
 	// check that StartIP of the range has valid offset.
 	// all ranges have same size, so we can simply check that (StartIP offset) % pa.cfg.PerNodeBlockSize == 0
 	if pa.canUseNetworkAddress() {
-		if math.Mod(float64(distanceFromNetworkStart), float64(pa.cfg.PerNodeBlockSize)) != 0 {
+		if new(big.Int).Mod(allocationOffset, blockSize).Sign() != 0 {
 			return fmt.Errorf("invalid start IP offset")
 		}
 	} else {
-		if distanceFromNetworkStart < 1 ||
-			// -1 required because we skip network address (e.g. in 192.168.0.0/24, first allocation will be 192.168.0.1)
-			math.Mod(float64(distanceFromNetworkStart)-1, float64(pa.cfg.PerNodeBlockSize)) != 0 {
+		if distanceFromNetworkStart.Sign() < 1 {
+			return fmt.Errorf("invalid start IP offset")
+		}
+		allocationOffset.Sub(allocationOffset, big.NewInt(1))
+		// -1 required because we skip network address (e.g. in 192.168.0.0/24, first allocation will be 192.168.0.1)
+		if new(big.Int).Mod(allocationOffset, blockSize).Sign() != 0 {
 			return fmt.Errorf("invalid start IP offset")
 		}
 	}
-	if ip.Distance(allocRange.StartIP, allocRange.EndIP) != int64(pa.cfg.PerNodeBlockSize)-1 {
+	allocationSize, err := ip.Distance(allocRange.StartIP, allocRange.EndIP)
+	if err != nil {
+		return fmt.Errorf("failed to calculate allocation size: %w", err)
+	}
+	expectedAllocationSize := new(big.Int).Sub(new(big.Int).Set(blockSize), big.NewInt(1))
+	if allocationSize.Cmp(expectedAllocationSize) != 0 {
 		return fmt.Errorf("ip count mismatch")
 	}
 	// for single IP ranges we need to discard allocation if it matches the gateway

--- a/pkg/ipam-controller/allocator/allocator_test.go
+++ b/pkg/ipam-controller/allocator/allocator_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"net"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -712,6 +713,62 @@ var _ = Describe("Allocator", func() {
 		})
 
 		// IPv6 tests
+		It("ipv6 - reports exhaustion after a /64-sized excluded suffix", func() {
+			pool := &ipamv1alpha1.IPPool{
+				ObjectMeta: v1.ObjectMeta{Name: "test-pool"},
+				Spec: ipamv1alpha1.IPPoolSpec{
+					Subnet:           "2001:db8::/64",
+					PerNodeBlockSize: 16,
+					Exclusions: []ipamv1alpha1.ExcludeRange{
+						{StartIP: "2001:db8::11", EndIP: "2001:db8::ffff:ffff:ffff:ffff"},
+					},
+				},
+			}
+			a := allocator.CreatePoolAllocatorFromIPPool(ctx, pool, sets.New(testNodeName1, testNodeName2))
+			node1Alloc, err := a.AllocateFromPool(ctx, testNodeName1)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(node1Alloc.StartIP.String()).To(Equal("2001:db8::1"))
+			Expect(node1Alloc.EndIP.String()).To(Equal("2001:db8::10"))
+			_, err = a.AllocateFromPool(ctx, testNodeName2)
+			Expect(err).To(MatchError(allocator.ErrNoFreeRanges))
+		})
+
+		It("ipv6 - skips an exclusion farther than int64 and preserves a usable suffix", func() {
+			pool := &ipamv1alpha1.IPPool{
+				ObjectMeta: v1.ObjectMeta{Name: "test-pool"},
+				Spec: ipamv1alpha1.IPPoolSpec{
+					Subnet:           "2001:db8::/63",
+					PerNodeBlockSize: 16,
+					Exclusions: []ipamv1alpha1.ExcludeRange{
+						{StartIP: "2001:db8::11", EndIP: "2001:db8:0:1::10"},
+					},
+				},
+			}
+			a := allocator.CreatePoolAllocatorFromIPPool(ctx, pool, sets.New(testNodeName1, testNodeName2))
+			_, err := a.AllocateFromPool(ctx, testNodeName1)
+			Expect(err).NotTo(HaveOccurred())
+			node2Alloc, err := a.AllocateFromPool(ctx, testNodeName2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(node2Alloc.StartIP.String()).To(Equal("2001:db8:0:1::11"))
+			Expect(node2Alloc.EndIP.String()).To(Equal("2001:db8:0:1::20"))
+		})
+
+		It("ipv6 - reports exhaustion when per-node exclusions cover every block", func() {
+			pool := &ipamv1alpha1.IPPool{
+				ObjectMeta: v1.ObjectMeta{Name: "test-pool"},
+				Spec: ipamv1alpha1.IPPoolSpec{
+					Subnet:           "2001:db8::/64",
+					PerNodeBlockSize: 16,
+					PerNodeExclusions: []ipamv1alpha1.ExcludeIndexRange{
+						{StartIndex: 0, EndIndex: 15},
+					},
+				},
+			}
+			a := allocator.CreatePoolAllocatorFromIPPool(ctx, pool, sets.New(testNodeName1))
+			_, err := a.AllocateFromPool(ctx, testNodeName1)
+			Expect(err).To(MatchError(allocator.ErrNoFreeRanges))
+		})
+
 		It("ipv6 - single exclusion covering entire first range - skips to next range", func() {
 			pool := &ipamv1alpha1.IPPool{
 				ObjectMeta: v1.ObjectMeta{Name: "test-pool"},
@@ -856,8 +913,12 @@ var _ = Describe("Allocator", func() {
 				nodeName := fmt.Sprintf("node-%d", i)
 				nodeAlloc, err := a.AllocateFromPool(ctx, nodeName)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(nodeAlloc.StartIP.String()).To(Equal(ip.NextIPWithOffset(baseIP, int64(i*10)).String()))
-				Expect(nodeAlloc.EndIP.String()).To(Equal(ip.NextIPWithOffset(baseIP, int64(i*10)+9).String()))
+				expectedStartIP, err := ip.NextIPWithOffset(baseIP, big.NewInt(int64(i*10)))
+				Expect(err).ToNot(HaveOccurred())
+				expectedEndIP, err := ip.NextIPWithOffset(baseIP, big.NewInt(int64(i*10)+9))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(nodeAlloc.StartIP.String()).To(Equal(expectedStartIP.String()))
+				Expect(nodeAlloc.EndIP.String()).To(Equal(expectedEndIP.String()))
 				if i%100 == 0 {
 					GinkgoWriter.Printf("allocated %d nodes\n", i)
 				}

--- a/pkg/ipam-controller/controllers/cidrpool/cidrpool.go
+++ b/pkg/ipam-controller/controllers/cidrpool/cidrpool.go
@@ -15,7 +15,9 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math/big"
 	"net"
 	"reflect"
 	"sort"
@@ -48,6 +50,8 @@ type CIDRPoolReconciler struct {
 	Scheme   *runtime.Scheme
 	recorder record.EventRecorder
 }
+
+var errNoFreePrefixes = errors.New("no free prefixes")
 
 // Reconcile contains logic to sync CIDRPool objects
 func (r *CIDRPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -85,14 +89,24 @@ func (r *CIDRPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	allocationsByNodeName, allocationsByPrefix := r.getValidExistingAllocationsMaps(ctx, pool, nodes)
 	staticAllocationsByNodeName, staticAllocationsByPrefix := r.getStaticAllocationsMaps(pool)
 
-	subnetGenFunc := ip.GetSubnetGen(cidrNetwork, pool.Spec.PerNodeNetworkPrefix)
+	subnetIterator, err := ip.NewSubnetIterator(cidrNetwork, pool.Spec.PerNodeNetworkPrefix)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create subnet iterator: %w", err)
+	}
+	mergedExclusions := ipamv1alpha1.MergeExcludeRanges(pool.Spec.Exclusions)
+	perNodePrefixFullyExcluded := ipamv1alpha1.ExcludeIndexRangesCover(
+		pool.Spec.PerNodeExclusions, lastUsableIndex(cidrNetwork, pool.Spec.PerNodeNetworkPrefix))
 	for _, node := range nodes {
 		if _, allocationExist := allocationsByNodeName[node]; allocationExist {
 			continue
 		}
 		nodeAlloc := r.getStaticAllocationForNodeIfExist(node, pool, staticAllocationsByNodeName)
 		if nodeAlloc == nil {
-			nodeAlloc = r.getNewAllocationForNode(subnetGenFunc, node, pool, allocationsByPrefix, staticAllocationsByPrefix)
+			nodeAlloc, err = r.getNewAllocationForNode(ctx, subnetIterator, node, pool, allocationsByPrefix,
+				staticAllocationsByPrefix, mergedExclusions, perNodePrefixFullyExcluded)
+			if err != nil && !errors.Is(err, errNoFreePrefixes) {
+				return ctrl.Result{}, err
+			}
 		}
 		if nodeAlloc == nil {
 			msg := fmt.Sprintf("failed to allocated prefix for Node: %s, no free prefixes", node)
@@ -124,14 +138,29 @@ func (r *CIDRPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return ctrl.Result{}, nil
 }
 
-// create new allocation for the node, returns nil if can't generate a subnet because lack of free prefixes
-func (r *CIDRPoolReconciler) getNewAllocationForNode(subnetGen func() *net.IPNet, node string,
+// getNewAllocationForNode returns errNoFreePrefixes when no prefix is available for the node.
+func (r *CIDRPoolReconciler) getNewAllocationForNode(
+	ctx context.Context,
+	subnetIterator *ip.SubnetIterator,
+	node string,
 	pool *ipamv1alpha1.CIDRPool,
 	allocByPrefix map[string]*ipamv1alpha1.CIDRPoolAllocation,
-	staticAllocByPrefix map[string]*ipamv1alpha1.CIDRPoolStaticAllocation) *ipamv1alpha1.CIDRPoolAllocation {
+	staticAllocByPrefix map[string]*ipamv1alpha1.CIDRPoolStaticAllocation,
+	mergedExclusions []ipamv1alpha1.ExcludeRange,
+	perNodePrefixFullyExcluded bool,
+) (*ipamv1alpha1.CIDRPoolAllocation, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if perNodePrefixFullyExcluded {
+		return nil, errNoFreePrefixes
+	}
 	var nodePrefix *net.IPNet
 	for {
-		nodePrefix = subnetGen()
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		nodePrefix = subnetIterator.Next()
 		if nodePrefix == nil {
 			break
 		}
@@ -146,13 +175,19 @@ func (r *CIDRPoolReconciler) getNewAllocationForNode(subnetGen func() *net.IPNet
 
 		// skip prefix if it is fully excluded
 		if r.isPrefixFullyExcluded(nodePrefix.String(), pool) {
+			exclusionEnd := overlappingExclusionEnd(nodePrefix, mergedExclusions)
+			if exclusionEnd != nil {
+				if err := subnetIterator.AdvancePastIP(exclusionEnd); err != nil {
+					return nil, fmt.Errorf("failed to skip excluded prefixes: %w", err)
+				}
+			}
 			continue
 		}
 
 		break
 	}
 	if nodePrefix == nil {
-		return nil
+		return nil, errNoFreePrefixes
 	}
 	gateway := ""
 	if pool.Spec.GatewayIndex != nil {
@@ -162,7 +197,43 @@ func (r *CIDRPoolReconciler) getNewAllocationForNode(subnetGen func() *net.IPNet
 		NodeName: node,
 		Prefix:   nodePrefix.String(),
 		Gateway:  gateway,
+	}, nil
+}
+
+// lastUsableIndex returns the last address index considered by isPrefixFullyExcluded for each generated prefix.
+func lastUsableIndex(parent *net.IPNet, prefixSize int32) *big.Int {
+	_, totalBits := parent.Mask.Size()
+	hostBits := int64(totalBits) - int64(prefixSize)
+	lastIndex := new(big.Int).Sub(
+		new(big.Int).Exp(big.NewInt(2), big.NewInt(hostBits), nil), big.NewInt(1))
+	if parent.IP.To4() != nil && hostBits > 1 {
+		// LastIP excludes the broadcast address for ordinary IPv4 prefixes.
+		lastIndex.Sub(lastIndex, big.NewInt(1))
 	}
+	return lastIndex
+}
+
+// overlappingExclusionEnd returns the furthest end of a global exclusion intersecting prefix.
+// The caller uses it only after the prefix is known to be fully excluded, so advancing to this endpoint cannot skip
+// a usable prefix. The boundary prefix is evaluated normally when the exclusion ends partway through it.
+func overlappingExclusionEnd(prefix *net.IPNet, exclusions []ipamv1alpha1.ExcludeRange) net.IP {
+	firstIP := prefix.IP
+	lastIP := ip.LastIP(prefix)
+	var furthestEnd net.IP
+	for _, exclusion := range exclusions {
+		startIP := net.ParseIP(exclusion.StartIP)
+		endIP := net.ParseIP(exclusion.EndIP)
+		if startIP == nil || endIP == nil || ip.Cmp(endIP, firstIP) < 0 {
+			continue
+		}
+		if ip.Cmp(startIP, lastIP) > 0 {
+			break
+		}
+		if furthestEnd == nil || ip.Cmp(endIP, furthestEnd) > 0 {
+			furthestEnd = endIP
+		}
+	}
+	return furthestEnd
 }
 
 // builds CIDRPoolAllocation from the CIDRPoolStaticAllocation if it exist for the node

--- a/pkg/ipam-controller/controllers/cidrpool/cidrpool_test.go
+++ b/pkg/ipam-controller/controllers/cidrpool/cidrpool_test.go
@@ -14,9 +14,11 @@
 package controllers
 
 import (
+	"net"
 	"time"
 
 	ipamv1alpha1 "github.com/Mellanox/nvidia-k8s-ipam/api/v1alpha1"
+	"github.com/Mellanox/nvidia-k8s-ipam/pkg/ip"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -153,7 +155,91 @@ var _ = Describe("CIDRPool controller", func() {
 			g.Expect(cidrPool.Status.Allocations[1].Prefix).To(Equal("10.10.3.0/24"))
 		}).WithTimeout(time.Second * 10).WithPolling(time.Second).Should(Succeed())
 	})
+
+	Context("IPv6 allocation exhaustion", func() {
+		It("reports exhaustion after a /64-sized excluded suffix", func() {
+			pool := &ipamv1alpha1.CIDRPool{
+				Spec: ipamv1alpha1.CIDRPoolSpec{
+					CIDR:                 "2001:db8::/64",
+					PerNodeNetworkPrefix: 128,
+					Exclusions: []ipamv1alpha1.ExcludeRange{
+						{StartIP: "2001:db8::1", EndIP: "2001:db8::ffff:ffff:ffff:ffff"},
+					},
+				},
+			}
+			iterator, mergedExclusions, perNodeFullyExcluded := allocationInputs(pool)
+			r := &CIDRPoolReconciler{}
+			allocations := map[string]*ipamv1alpha1.CIDRPoolAllocation{}
+			staticAllocations := map[string]*ipamv1alpha1.CIDRPoolStaticAllocation{}
+
+			first, err := r.getNewAllocationForNode(ctx, iterator, "node-1", pool, allocations,
+				staticAllocations, mergedExclusions, perNodeFullyExcluded)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(first).NotTo(BeNil())
+			Expect(first.Prefix).To(Equal("2001:db8::/128"))
+			allocations[first.Prefix] = first
+
+			second, err := r.getNewAllocationForNode(ctx, iterator, "node-2", pool, allocations,
+				staticAllocations, mergedExclusions, perNodeFullyExcluded)
+			Expect(err).To(MatchError(errNoFreePrefixes))
+			Expect(second).To(BeNil())
+		})
+
+		It("allocates the partially excluded boundary prefix", func() {
+			pool := &ipamv1alpha1.CIDRPool{
+				Spec: ipamv1alpha1.CIDRPoolSpec{
+					CIDR:                 "2001:db8::/64",
+					PerNodeNetworkPrefix: 80,
+					Exclusions: []ipamv1alpha1.ExcludeRange{
+						{StartIP: "2001:db8::", EndIP: "2001:db8:0:0:abcd::7fff"},
+					},
+				},
+			}
+			iterator, mergedExclusions, perNodeFullyExcluded := allocationInputs(pool)
+			r := &CIDRPoolReconciler{}
+
+			allocation, err := r.getNewAllocationForNode(ctx, iterator, "node-1", pool,
+				map[string]*ipamv1alpha1.CIDRPoolAllocation{}, map[string]*ipamv1alpha1.CIDRPoolStaticAllocation{},
+				mergedExclusions, perNodeFullyExcluded)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allocation).NotTo(BeNil())
+			Expect(allocation.Prefix).To(Equal("2001:db8:0:0:abcd::/80"))
+		})
+
+		It("reports exhaustion when per-node exclusions cover every prefix", func() {
+			pool := &ipamv1alpha1.CIDRPool{
+				Spec: ipamv1alpha1.CIDRPoolSpec{
+					CIDR:                 "2001:db8::/64",
+					PerNodeNetworkPrefix: 128,
+					PerNodeExclusions: []ipamv1alpha1.ExcludeIndexRange{
+						{StartIndex: 0, EndIndex: 0},
+					},
+				},
+			}
+			iterator, mergedExclusions, perNodeFullyExcluded := allocationInputs(pool)
+			Expect(perNodeFullyExcluded).To(BeTrue())
+			r := &CIDRPoolReconciler{}
+
+			allocation, err := r.getNewAllocationForNode(ctx, iterator, "node-1", pool,
+				map[string]*ipamv1alpha1.CIDRPoolAllocation{}, map[string]*ipamv1alpha1.CIDRPoolStaticAllocation{},
+				mergedExclusions, perNodeFullyExcluded)
+			Expect(err).To(MatchError(errNoFreePrefixes))
+			Expect(allocation).To(BeNil())
+		})
+	})
 })
+
+func allocationInputs(pool *ipamv1alpha1.CIDRPool) (*ip.SubnetIterator, []ipamv1alpha1.ExcludeRange, bool) {
+	GinkgoHelper()
+	_, network, err := net.ParseCIDR(pool.Spec.CIDR)
+	Expect(err).NotTo(HaveOccurred())
+	iterator, err := ip.NewSubnetIterator(network, pool.Spec.PerNodeNetworkPrefix)
+	Expect(err).NotTo(HaveOccurred())
+	return iterator,
+		ipamv1alpha1.MergeExcludeRanges(pool.Spec.Exclusions),
+		ipamv1alpha1.ExcludeIndexRangesCover(
+			pool.Spec.PerNodeExclusions, lastUsableIndex(network, pool.Spec.PerNodeNetworkPrefix))
+}
 
 func getTestNode(name string) *corev1.Node {
 	return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}

--- a/pkg/ipam-node/handlers/allocate.go
+++ b/pkg/ipam-node/handlers/allocate.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"net"
 	"slices"
 	"time"
@@ -160,7 +161,12 @@ func (h *Handlers) allocateInPool(poolName string, reqLog logr.Logger,
 		}
 
 		if params.Features.AllocateIpWithIndex != nil {
-			selectedIP := ip.NextIPWithOffset(rangeStart, int64(*params.Features.AllocateIpWithIndex))
+			selectedIP, err := ip.NextIPWithOffset(
+				rangeStart, big.NewInt(int64(*params.Features.AllocateIpWithIndex)))
+			if err != nil {
+				return PoolAlloc{}, status.Errorf(codes.InvalidArgument,
+					"requested IP index \"%d\" is outside of the given chunk", *params.Features.AllocateIpWithIndex)
+			}
 			if selectedIP.Equal(gateway) {
 				return PoolAlloc{}, status.Errorf(codes.InvalidArgument,
 					"requested IP index \"%d\" is the actual gateway, "+


### PR DESCRIPTION
The PR addresses the following problems:

### 1. Prevent unbounded IPv6 IPPool exhaustion scans
#### Problem
IPPool exclusion skipping previously depended on an int64 distance. Distances larger than MaxInt64 produced a negative sentinel, which caused the skip calculation to advance only one allocation block at a time. For example, exhausting an IPv6 /64 with a block size of 16 could require approximately 2^60 iterations and monopolize a controller worker.
#### Resolution
The existing IP arithmetic APIs now use exact, error-returning arithmetic: ip.Distance returns a *big.Int, and ip.NextIPWithOffset accepts a *big.Int.
The allocator uses these exact values to jump across merged global exclusion intervals while retaining block alignment. If an exclusion ends inside an allocation block, that partially usable boundary block is still evaluated normally. Per-node exclusions covering every index in a block are detected before scanning, and context cancellation is honored while candidate ranges are scanned.
### 2. Prevent CIDRPool exhaustion from enumerating every prefix
#### Problem
CIDRPool previously generated candidate prefixes sequentially. Exhausting a /64 divided into /128 per-node prefixes could therefore require approximately 2^64 iterations.
#### Resolution
The sequential subnet generator has been replaced with a validated, error-returning subnet iterator. After a candidate prefix is found to be fully excluded, the controller uses merged global exclusion intervals to advance directly to the prefix containing the first address after the relevant interval.
Partially excluded boundary prefixes are evaluated normally instead of being skipped. Uniform per-node index exclusions that cover every generated prefix are detected before iteration. Iterator construction and advancement errors are propagated, and allocation honors context cancellation before and during scanning.
The iterator also validates network masks, address-family consistency, host bits, and prefix sizes, preventing malformed or mismatched networks from producing invalid prefixes.
### 3. Preserve distant persisted IPv6 allocations exactly
#### Problem
Persisted IPPool allocations were previously validated using int64 distances and float64 modulo operations. Offsets above MaxInt64 could be rejected through the overflow sentinel, while values above 2^53 could lose alignment precision. This could cause valid allocations to be discarded or malformed allocations to be accepted during reconciliation.
#### Resolution
Persisted allocation validation now uses exact big.Int arithmetic for network offsets, block alignment, and allocation size. Valid allocations located far inside large IPv6 networks are retained when status is reloaded, while misaligned, malformed, or out-of-range allocations are rejected precisely.