### PR TITLE
feat: configurable stale-allocation cleanup and release cooldown for IP allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,10 @@ Node daemon flags:
                 The address the metric endpoint binds to. (default ":8080")
       --node-name string                                                                                                                                                                             
                 The name of the Node on which the daemon runs
+      --stale-ip-check-count-before-release int                                                                                                                                                      
+                Number of consecutive failed checks before a stale IP allocation is released. Together with stale-ip-check-interval this defines the effective TTL: since checks happen every stale-ip-check-interval and a check only starts counting once it observes a missing Pod, an allocation may remain without a matching Pod for up to roughly stale-ip-check-interval * (stale-ip-check-count-before-release + 1) before it is released (default 3)
+      --stale-ip-check-interval duration                                                                                                                                                             
+                Delay between checks for stale IP allocations (allocations with no matching Pod) (default 1m0s)
       --store-file string                                                                                                                                                                            
                 Path of the file which used to store allocations (default "/var/lib/cni/nv-ipam/store")
       --ippools-namespace string

--- a/README.md
+++ b/README.md
@@ -560,10 +560,12 @@ Node daemon flags:
                 The address the metric endpoint binds to. (default ":8080")
       --node-name string                                                                                                                                                                             
                 The name of the Node on which the daemon runs
+      --released-ip-cooldown duration                                                                                                                                                                
+                Minimum time a released IP allocation is retained before it becomes eligible for reuse. Applies to normal releases (e.g. CNI DEL), unlike stale-ip-check-interval/stale-ip-check-count-before-release which only apply to allocations whose Pod can no longer be found. Zero disables the cooldown, releasing allocations for reuse immediately. The actual delay may exceed this value by up to stale-ip-check-interval, since expiry is checked on that cadence
       --stale-ip-check-count-before-release int                                                                                                                                                      
                 Number of consecutive failed checks before a stale IP allocation is released. Together with stale-ip-check-interval this defines the effective TTL: since checks happen every stale-ip-check-interval and a check only starts counting once it observes a missing Pod, an allocation may remain without a matching Pod for up to roughly stale-ip-check-interval * (stale-ip-check-count-before-release + 1) before it is released (default 3)
       --stale-ip-check-interval duration                                                                                                                                                             
-                Delay between checks for stale IP allocations (allocations with no matching Pod) (default 1m0s)
+                Delay between checks for stale IP allocations (allocations with no matching Pod). Also gates how often released-ip-cooldown expiry is checked (default 1m0s)
       --store-file string                                                                                                                                                                            
                 Path of the file which used to store allocations (default "/var/lib/cni/nv-ipam/store")
       --ippools-namespace string

--- a/cmd/ipam-node/app/app.go
+++ b/cmd/ipam-node/app/app.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/gofrs/flock"
@@ -278,7 +277,8 @@ func RunNodeDaemon(ctx context.Context, config *rest.Config, opts *options.Optio
 			}
 			return
 		}
-		c := cleaner.New(mgr.GetClient(), k8sClient, store, poolManager, time.Minute, 3)
+		c := cleaner.New(mgr.GetClient(), k8sClient, store, poolManager,
+			opts.StaleIPCheckInterval, opts.StaleIPCheckCountBeforeRelease)
 		c.Start(innerCtx)
 		logger.Info("cleaner stopped")
 	}()

--- a/cmd/ipam-node/app/app.go
+++ b/cmd/ipam-node/app/app.go
@@ -278,7 +278,7 @@ func RunNodeDaemon(ctx context.Context, config *rest.Config, opts *options.Optio
 			return
 		}
 		c := cleaner.New(mgr.GetClient(), k8sClient, store, poolManager,
-			opts.StaleIPCheckInterval, opts.StaleIPCheckCountBeforeRelease)
+			opts.StaleIPCheckInterval, opts.StaleIPCheckCountBeforeRelease, opts.ReleasedIPCooldown)
 		c.Start(innerCtx)
 		logger.Info("cleaner stopped")
 	}()
@@ -315,7 +315,7 @@ func initGRPCServer(ctx context.Context, opts *options.Options,
 		middleware.LogCallMiddleware))
 
 	nodev1.RegisterIPAMServiceServer(grpcServer,
-		handlers.New(poolConfReader, store, allocator.NewIPAllocator))
+		handlers.New(poolConfReader, store, allocator.NewIPAllocator, opts.ReleasedIPCooldown))
 	return grpcServer, listener, nil
 }
 

--- a/cmd/ipam-node/app/options/options.go
+++ b/cmd/ipam-node/app/options/options.go
@@ -37,6 +37,10 @@ const (
 	// DefaultStaleIPCheckCountBeforeRelease contains default number of checks to do before
 	// an allocation with no matching Pod is released
 	DefaultStaleIPCheckCountBeforeRelease = 3
+	// DefaultReleasedIPCooldown contains default minimum time a released IP allocation is
+	// retained before it becomes eligible for reuse. Zero disables the cooldown, preserving
+	// the legacy behavior of releasing allocations for reuse immediately.
+	DefaultReleasedIPCooldown = 0 * time.Second
 )
 
 // New initialize and return new Options object
@@ -62,6 +66,7 @@ func New() *Options {
 		CNIForcePoolName:               false,
 		StaleIPCheckInterval:           DefaultStaleIPCheckInterval,
 		StaleIPCheckCountBeforeRelease: DefaultStaleIPCheckCountBeforeRelease,
+		ReleasedIPCooldown:             DefaultReleasedIPCooldown,
 	}
 }
 
@@ -88,6 +93,9 @@ type Options struct {
 	// stale IP allocations cleanup
 	StaleIPCheckInterval           time.Duration
 	StaleIPCheckCountBeforeRelease int
+	// ReleasedIPCooldown is the minimum time a released IP allocation is retained before
+	// it becomes eligible for reuse. Zero disables the cooldown.
+	ReleasedIPCooldown time.Duration
 }
 
 // AddNamedFlagSets register flags for common options in NamedFlagSets
@@ -113,7 +121,8 @@ func (o *Options) AddNamedFlagSets(sharedFS *cliflag.NamedFlagSets) {
 	daemonFS.StringVar(&o.StoreFile, "store-file", o.StoreFile,
 		"Path of the file which used to store allocations")
 	daemonFS.DurationVar(&o.StaleIPCheckInterval, "stale-ip-check-interval", o.StaleIPCheckInterval,
-		"Delay between checks for stale IP allocations (allocations with no matching Pod)")
+		"Delay between checks for stale IP allocations (allocations with no matching Pod). "+
+			"Also gates how often released-ip-cooldown expiry is checked")
 	daemonFS.IntVar(&o.StaleIPCheckCountBeforeRelease, "stale-ip-check-count-before-release",
 		o.StaleIPCheckCountBeforeRelease,
 		"Number of consecutive failed checks before a stale IP allocation is released. "+
@@ -122,6 +131,13 @@ func (o *Options) AddNamedFlagSets(sharedFS *cliflag.NamedFlagSets) {
 			"counting once it observes a missing Pod, an allocation may remain without a "+
 			"matching Pod for up to roughly stale-ip-check-interval * "+
 			"(stale-ip-check-count-before-release + 1) before it is released")
+	daemonFS.DurationVar(&o.ReleasedIPCooldown, "released-ip-cooldown", o.ReleasedIPCooldown,
+		"Minimum time a released IP allocation is retained before it becomes eligible for reuse. "+
+			"Applies to normal releases (e.g. CNI DEL), unlike stale-ip-check-interval/"+
+			"stale-ip-check-count-before-release which only apply to allocations whose Pod can no "+
+			"longer be found. Zero disables the cooldown, releasing allocations for reuse immediately. "+
+			"The actual delay may exceed this value by up to stale-ip-check-interval, since expiry is "+
+			"checked on that cadence")
 
 	cniFS := sharedFS.FlagSet("Shim CNI Configuration")
 	cniFS.StringVar(&o.CNIBinDir,
@@ -163,6 +179,9 @@ func (o *Options) Validate() error {
 	}
 	if o.StaleIPCheckCountBeforeRelease < 1 {
 		return fmt.Errorf("stale-ip-check-count-before-release must be at least 1")
+	}
+	if o.ReleasedIPCooldown < 0 {
+		return fmt.Errorf("released-ip-cooldown must not be negative")
 	}
 	if err := o.verifyPaths(); err != nil {
 		return err

--- a/cmd/ipam-node/app/options/options.go
+++ b/cmd/ipam-node/app/options/options.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"time"
 
 	cliflag "k8s.io/component-base/cli/flag"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -31,6 +32,11 @@ const (
 	// DefaultStoreFile contains path of the default store file
 	DefaultStoreFile   = "/var/lib/cni/nv-ipam/store"
 	DefaultBindAddress = cniTypes.DefaultDaemonSocket
+	// DefaultStaleIPCheckInterval contains default delay between checks for stale allocations
+	DefaultStaleIPCheckInterval = time.Minute
+	// DefaultStaleIPCheckCountBeforeRelease contains default number of checks to do before
+	// an allocation with no matching Pod is released
+	DefaultStaleIPCheckCountBeforeRelease = 3
 )
 
 // New initialize and return new Options object
@@ -44,16 +50,18 @@ func New() *Options {
 		StoreFile:      DefaultStoreFile,
 		PoolsNamespace: "kube-system",
 		// shim CNI parameters
-		CNIBinDir:                   "/opt/cni/bin",
-		CNIBinFile:                  "/nv-ipam",
-		CNISkipBinFileCopy:          false,
-		CNISkipConfigCreation:       false,
-		CNIDaemonSocket:             cniTypes.DefaultDaemonSocket,
-		CNIDaemonCallTimeoutSeconds: 5,
-		CNIConfDir:                  cniTypes.DefaultConfDir,
-		CNILogLevel:                 cniTypes.DefaultLogLevel,
-		CNILogFile:                  cniTypes.DefaultLogFile,
-		CNIForcePoolName:            false,
+		CNIBinDir:                      "/opt/cni/bin",
+		CNIBinFile:                     "/nv-ipam",
+		CNISkipBinFileCopy:             false,
+		CNISkipConfigCreation:          false,
+		CNIDaemonSocket:                cniTypes.DefaultDaemonSocket,
+		CNIDaemonCallTimeoutSeconds:    5,
+		CNIConfDir:                     cniTypes.DefaultConfDir,
+		CNILogLevel:                    cniTypes.DefaultLogLevel,
+		CNILogFile:                     cniTypes.DefaultLogFile,
+		CNIForcePoolName:               false,
+		StaleIPCheckInterval:           DefaultStaleIPCheckInterval,
+		StaleIPCheckCountBeforeRelease: DefaultStaleIPCheckCountBeforeRelease,
 	}
 }
 
@@ -77,6 +85,9 @@ type Options struct {
 	CNILogFile                  string
 	CNILogLevel                 string
 	CNIForcePoolName            bool
+	// stale IP allocations cleanup
+	StaleIPCheckInterval           time.Duration
+	StaleIPCheckCountBeforeRelease int
 }
 
 // AddNamedFlagSets register flags for common options in NamedFlagSets
@@ -101,6 +112,16 @@ func (o *Options) AddNamedFlagSets(sharedFS *cliflag.NamedFlagSets) {
 		"GPRC server bind address. e.g.: tcp://127.0.0.1:9092, unix:///var/lib/foo")
 	daemonFS.StringVar(&o.StoreFile, "store-file", o.StoreFile,
 		"Path of the file which used to store allocations")
+	daemonFS.DurationVar(&o.StaleIPCheckInterval, "stale-ip-check-interval", o.StaleIPCheckInterval,
+		"Delay between checks for stale IP allocations (allocations with no matching Pod)")
+	daemonFS.IntVar(&o.StaleIPCheckCountBeforeRelease, "stale-ip-check-count-before-release",
+		o.StaleIPCheckCountBeforeRelease,
+		"Number of consecutive failed checks before a stale IP allocation is released. "+
+			"Together with stale-ip-check-interval this defines the effective TTL: "+
+			"since checks happen every stale-ip-check-interval and a check only starts "+
+			"counting once it observes a missing Pod, an allocation may remain without a "+
+			"matching Pod for up to roughly stale-ip-check-interval * "+
+			"(stale-ip-check-count-before-release + 1) before it is released")
 
 	cniFS := sharedFS.FlagSet("Shim CNI Configuration")
 	cniFS.StringVar(&o.CNIBinDir,
@@ -136,6 +157,12 @@ func (o *Options) Validate() error {
 	_, _, err := ParseBindAddress(o.BindAddress)
 	if err != nil {
 		return fmt.Errorf("bind-address is invalid: %v", err)
+	}
+	if o.StaleIPCheckInterval <= 0 {
+		return fmt.Errorf("stale-ip-check-interval must be a positive duration")
+	}
+	if o.StaleIPCheckCountBeforeRelease < 1 {
+		return fmt.Errorf("stale-ip-check-count-before-release must be at least 1")
 	}
 	if err := o.verifyPaths(); err != nil {
 		return err

--- a/pkg/ipam-node/allocator/allocator_test.go
+++ b/pkg/ipam-node/allocator/allocator_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -131,7 +132,7 @@ var _ = Describe("allocator", func() {
 			a := mkAlloc(store)
 			Expect(store.Reserve(testPoolName, testContainerID, testIFName, types.ReservationMetadata{}, net.IP{192, 168, 1, 3})).
 				NotTo(HaveOccurred())
-			store.ReleaseReservationByID(testPoolName, testContainerID, testIFName)
+			store.ReleaseReservationByID(testPoolName, testContainerID, testIFName, 0)
 			checkAlloc(a, "0", net.IP{192, 168, 1, 4})
 			checkAlloc(a, "1", net.IP{192, 168, 1, 5})
 			checkAlloc(a, "2", net.IP{192, 168, 1, 6})
@@ -299,11 +300,31 @@ var _ = Describe("allocator", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.Address.String()).To(Equal("192.168.1.2/29"))
 
-			store.ReleaseReservationByID(testPoolName, testContainerID, testIFName)
+			store.ReleaseReservationByID(testPoolName, testContainerID, testIFName, 0)
 
 			res, err = alloc.Allocate(testContainerID, testIFName, types.ReservationMetadata{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.Address.String()).To(Equal("192.168.1.3/29"))
+		})
+
+		It("fails while its own prior reservation is cooling down, even for a free pool", func() {
+			store, err := storePkg.New(
+				filepath.Join(GinkgoT().TempDir(), "test_store")).Open(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				_ = store.Commit()
+			}()
+			alloc := mkAlloc(store)
+			res, err := alloc.Allocate(testContainerID, testIFName, types.ReservationMetadata{}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Address.String()).To(Equal("192.168.1.2/29"))
+
+			// released with a cooldown: kept on file, blocking 192.168.1.2 from reuse
+			// by anyone, including this same container, until the cooldown elapses
+			store.ReleaseReservationByID(testPoolName, testContainerID, testIFName, time.Minute)
+
+			_, err = alloc.Allocate(testContainerID, testIFName, types.ReservationMetadata{}, nil)
+			Expect(err).To(MatchError(storePkg.ErrReservationAlreadyExist))
 		})
 	})
 	Context("when out of ips", func() {

--- a/pkg/ipam-node/cleaner/cleaner.go
+++ b/pkg/ipam-node/cleaner/cleaner.go
@@ -166,11 +166,14 @@ func (c *cleaner) loop(ctx context.Context) error {
 		if count > c.checkCountBeforeRelease {
 			keyFields := strings.SplitN(k, "|", 3)
 			poolKey, containerID, ifName := keyFields[0], keyFields[1], keyFields[2]
-			logger.Info("stale reservation released", "poolKey", poolKey,
-				"container_id", containerID, "interface_name", ifName)
-			// an orphaned allocation (no matching Pod) is unrelated to the release
-			// cooldown; remove it immediately
-			session.ReleaseReservationByID(poolKey, containerID, ifName, 0)
+			switch {
+			case session.ReleaseReservationByID(poolKey, containerID, ifName, c.releaseCooldown):
+				logger.Info("stale reservation released", "poolKey", poolKey,
+					"container_id", containerID, "interface_name", ifName)
+			case c.releaseCooldown > 0:
+				logger.Info("stale reservation marked released, pending release cooldown before its IP is freed",
+					"poolKey", poolKey, "container_id", containerID, "interface_name", ifName)
+			}
 		}
 	}
 	// remove empty pools if they don't have configuration in the k8s API

--- a/pkg/ipam-node/cleaner/cleaner.go
+++ b/pkg/ipam-node/cleaner/cleaner.go
@@ -43,11 +43,17 @@ type Cleaner interface {
 }
 
 // New creates and initialize new cleaner instance
-// "checkInterval" defines delay between checks for stale allocations.
+// "checkInterval" defines delay between checks for stale allocations. It also defines
+// how often reservations pending the release cooldown are checked for expiry.
 // "checkCountBeforeRelease: defines how many check to do before remove the allocation
+// "releaseCooldown" defines the minimum time a released reservation (IsReleased() == true)
+// is kept in the store before the cleaner removes it, freeing its IP for reuse. A value
+// <= 0 disables the cooldown check (released reservations are expected to have already
+// been removed immediately by the caller in that case).
 func New(cachedClient client.Client, directClient client.Client, store storePkg.Store, poolConfReader pool.ConfigReader,
 	checkInterval time.Duration,
-	checkCountBeforeRelease int) Cleaner {
+	checkCountBeforeRelease int,
+	releaseCooldown time.Duration) Cleaner {
 	return &cleaner{
 		cachedClient:            cachedClient,
 		directClient:            directClient,
@@ -55,6 +61,7 @@ func New(cachedClient client.Client, directClient client.Client, store storePkg.
 		poolConfReader:          poolConfReader,
 		checkInterval:           checkInterval,
 		checkCountBeforeRelease: checkCountBeforeRelease,
+		releaseCooldown:         releaseCooldown,
 		staleAllocations:        make(map[string]int),
 	}
 }
@@ -66,6 +73,7 @@ type cleaner struct {
 	poolConfReader          pool.ConfigReader
 	checkInterval           time.Duration
 	checkCountBeforeRelease int
+	releaseCooldown         time.Duration
 	// key is <pool_name>|<container_id>|<interface_name>, value is count of failed checks
 	staleAllocations map[string]int
 }
@@ -107,6 +115,18 @@ func (c *cleaner) loop(ctx context.Context) error {
 				"container_id", reservation.ContainerID, "interface_name", reservation.InterfaceName)
 			staleAllocKey := c.getStaleAllocKey(poolKey, reservation)
 			allReservations[staleAllocKey] = struct{}{}
+			if reservation.IsReleased() {
+				// reservation was already released by its owner (e.g. CNI DEL) and is only
+				// being retained for the release cooldown; it has no Pod to check against.
+				// Check expiry locally first to skip the store call while still cooling down.
+				if time.Since(reservation.ReleasedAt) >= c.releaseCooldown &&
+					session.ReleaseReservationByID(
+						poolKey, reservation.ContainerID, reservation.InterfaceName, c.releaseCooldown) {
+					resLogger.Info("release cooldown expired, removing reservation")
+				}
+				delete(c.staleAllocations, staleAllocKey)
+				continue
+			}
 			if reservation.Metadata.PodName == "" || reservation.Metadata.PodNamespace == "" {
 				resLogger.V(2).Info("reservation has no required metadata fields, skip")
 				continue
@@ -148,7 +168,9 @@ func (c *cleaner) loop(ctx context.Context) error {
 			poolKey, containerID, ifName := keyFields[0], keyFields[1], keyFields[2]
 			logger.Info("stale reservation released", "poolKey", poolKey,
 				"container_id", containerID, "interface_name", ifName)
-			session.ReleaseReservationByID(poolKey, containerID, ifName)
+			// an orphaned allocation (no matching Pod) is unrelated to the release
+			// cooldown; remove it immediately
+			session.ReleaseReservationByID(poolKey, containerID, ifName, 0)
 		}
 	}
 	// remove empty pools if they don't have configuration in the k8s API

--- a/pkg/ipam-node/cleaner/cleaner_test.go
+++ b/pkg/ipam-node/cleaner/cleaner_test.go
@@ -14,6 +14,7 @@
 package cleaner_test
 
 import (
+	"context"
 	"net"
 	"path/filepath"
 	"time"
@@ -26,6 +27,7 @@ import (
 
 	cleanerPkg "github.com/Mellanox/nvidia-k8s-ipam/pkg/ipam-node/cleaner"
 	storePkg "github.com/Mellanox/nvidia-k8s-ipam/pkg/ipam-node/store"
+	"github.com/Mellanox/nvidia-k8s-ipam/pkg/ipam-node/store/storetest"
 	"github.com/Mellanox/nvidia-k8s-ipam/pkg/ipam-node/types"
 	poolPkg "github.com/Mellanox/nvidia-k8s-ipam/pkg/pool"
 	poolMockPkg "github.com/Mellanox/nvidia-k8s-ipam/pkg/pool/mocks"
@@ -39,6 +41,9 @@ const (
 	testPool2     = "pool2"
 	testPool3     = "pool3"
 	testIFName    = "net0"
+	// used by the release cooldown tests
+	testReleaseCooldownIP = "192.168.10.100"
+	testPendingCooldownIP = "192.168.11.100"
 )
 
 func createPod(name, namespace string) string {
@@ -59,6 +64,8 @@ var _ = Describe("Cleaner", func() {
 		go func() {
 			defer GinkgoRecover()
 			defer close(done)
+			testCtx, testCancel := context.WithCancel(ctx)
+			defer testCancel()
 			storePath := filepath.Join(GinkgoT().TempDir(), "test_store")
 			store := storePkg.New(storePath)
 
@@ -68,12 +75,12 @@ var _ = Describe("Cleaner", func() {
 			// pool3 has config in the k8s API
 			poolManager.On("GetPoolByKey", testPool3).Return(&poolPkg.Pool{})
 
-			session, err := store.Open(ctx)
+			session, err := store.Open(testCtx)
 			Expect(err).NotTo(HaveOccurred())
 			// this will create empty pool config
 			session.SetLastReservedIP(testPool3, net.ParseIP("192.168.33.100"))
 
-			cleaner := cleanerPkg.New(fakeClient, k8sClient, store, poolManager, time.Millisecond*100, 3)
+			cleaner := cleanerPkg.New(fakeClient, k8sClient, store, poolManager, time.Millisecond*100, 3, 0)
 
 			pod1UID := createPod(testPodName1, testNamespace)
 			_ = createPod(testPodName2, testNamespace)
@@ -110,10 +117,10 @@ var _ = Describe("Cleaner", func() {
 			Expect(session.Commit()).NotTo(HaveOccurred())
 
 			go func() {
-				cleaner.Start(ctx)
+				cleaner.Start(testCtx)
 			}()
 			Eventually(func(g Gomega) {
-				store, err := store.Open(ctx)
+				store, err := store.Open(testCtx)
 				g.Expect(err).NotTo(HaveOccurred())
 				defer store.Cancel()
 				g.Expect(store.GetReservationByID(testPool1, "id1", testIFName)).NotTo(BeNil())
@@ -126,6 +133,104 @@ var _ = Describe("Cleaner", func() {
 					Not(ContainElement(testPool2))))
 			}, 10).Should(Succeed())
 
+		}()
+		Eventually(done, time.Minute).Should(BeClosed())
+	})
+
+	It("Release cooldown test", func() {
+		done := make(chan interface{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+			testCtx, testCancel := context.WithCancel(ctx)
+			defer testCancel()
+			storePath := filepath.Join(GinkgoT().TempDir(), "test_store_cooldown")
+			store := storePkg.New(storePath)
+
+			poolManager := poolMockPkg.NewManager(GinkgoT())
+
+			session, err := store.Open(testCtx)
+			Expect(err).NotTo(HaveOccurred())
+
+			checkInterval := time.Millisecond * 50
+			// short enough to keep the test fast; the point is only that it eventually
+			// elapses and the cleaner then removes the reservation
+			releaseCooldown := time.Millisecond * 100
+
+			Expect(session.Reserve(testPool1, "id1", testIFName, types.ReservationMetadata{},
+				net.ParseIP(testReleaseCooldownIP))).NotTo(HaveOccurred())
+			session.ReleaseReservationByID(testPool1, "id1", testIFName, releaseCooldown)
+
+			Expect(session.Commit()).NotTo(HaveOccurred())
+
+			cleaner := cleanerPkg.New(fakeClient, k8sClient, store, poolManager, checkInterval, 3, releaseCooldown)
+
+			go func() {
+				cleaner.Start(testCtx)
+			}()
+
+			// the cleaner ticks every checkInterval; once releaseCooldown has elapsed
+			// (in real time) a subsequent tick removes the reservation
+			Eventually(func(g Gomega) {
+				s, err := store.Open(testCtx)
+				g.Expect(err).NotTo(HaveOccurred())
+				defer s.Cancel()
+				g.Expect(storetest.FindReservation(s, testPool1, "id1", testIFName)).To(BeNil())
+			}, 10).Should(Succeed())
+
+			// the IP should be reusable now that the released reservation was removed
+			s, err := store.Open(testCtx)
+			Expect(err).NotTo(HaveOccurred())
+			defer s.Cancel()
+			Expect(s.Reserve(testPool1, "id2", testIFName, types.ReservationMetadata{},
+				net.ParseIP(testReleaseCooldownIP))).NotTo(HaveOccurred())
+		}()
+		Eventually(done, time.Minute).Should(BeClosed())
+	})
+
+	It("Reservation stays blocked until the release cooldown expires", func() {
+		done := make(chan interface{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+			testCtx, testCancel := context.WithCancel(ctx)
+			defer testCancel()
+			storePath := filepath.Join(GinkgoT().TempDir(), "test_store_cooldown_pending")
+			store := storePkg.New(storePath)
+
+			poolManager := poolMockPkg.NewManager(GinkgoT())
+
+			session, err := store.Open(testCtx)
+			Expect(err).NotTo(HaveOccurred())
+
+			checkInterval := time.Millisecond * 50
+			// Use a long enough cooldown to ensure the cleaner ticks several times before it expires
+			// Besides, a long cooldown ensures others cannot reuse the IP until the cooldown expires, which is what we want to test.
+			releaseCooldown := time.Minute
+
+			Expect(session.Reserve(testPool1, "id1", testIFName, types.ReservationMetadata{},
+				net.ParseIP(testPendingCooldownIP))).NotTo(HaveOccurred())
+			session.ReleaseReservationByID(testPool1, "id1", testIFName, releaseCooldown)
+			Expect(session.Commit()).NotTo(HaveOccurred())
+
+			cleaner := cleanerPkg.New(fakeClient, k8sClient, store, poolManager, checkInterval, 3, releaseCooldown)
+
+			go func() {
+				cleaner.Start(testCtx)
+			}()
+
+			// with a one-minute cooldown, the reservation must still be present (and
+			// its IP still blocked) across several cleaner ticks
+			Consistently(func(g Gomega) {
+				s, err := store.Open(testCtx)
+				g.Expect(err).NotTo(HaveOccurred())
+				defer s.Cancel()
+				g.Expect(storetest.FindReservation(s, testPool1, "id1", testIFName)).NotTo(BeNil())
+				// IP should still be blocked, so a new reservation with the same IP should fail
+				g.Expect(
+					s.Reserve(testPool1, "id2", testIFName, types.ReservationMetadata{},
+						net.ParseIP(testPendingCooldownIP))).To(MatchError(storePkg.ErrIPAlreadyReserved))
+			}, checkInterval*5, checkInterval).Should(Succeed())
 		}()
 		Eventually(done, time.Minute).Should(BeClosed())
 	})

--- a/pkg/ipam-node/cleaner/cleaner_test.go
+++ b/pkg/ipam-node/cleaner/cleaner_test.go
@@ -42,8 +42,10 @@ const (
 	testPool3     = "pool3"
 	testIFName    = "net0"
 	// used by the release cooldown tests
-	testReleaseCooldownIP = "192.168.10.100"
-	testPendingCooldownIP = "192.168.11.100"
+	testReleaseCooldownIP       = "192.168.10.100"
+	testPendingCooldownIP       = "192.168.11.100"
+	testOrphanCooldownIP        = "192.168.12.100"
+	testOrphanPendingCooldownIP = "192.168.13.100"
 )
 
 func createPod(name, namespace string) string {
@@ -230,6 +232,116 @@ var _ = Describe("Cleaner", func() {
 				g.Expect(
 					s.Reserve(testPool1, "id2", testIFName, types.ReservationMetadata{},
 						net.ParseIP(testPendingCooldownIP))).To(MatchError(storePkg.ErrIPAlreadyReserved))
+			}, checkInterval*5, checkInterval).Should(Succeed())
+		}()
+		Eventually(done, time.Minute).Should(BeClosed())
+	})
+
+	It("Orphan cleanup respects the release cooldown", func() {
+		done := make(chan interface{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+			testCtx, testCancel := context.WithCancel(ctx)
+			defer testCancel()
+			storePath := filepath.Join(GinkgoT().TempDir(), "test_store_orphan_cooldown")
+			store := storePkg.New(storePath)
+
+			poolManager := poolMockPkg.NewManager(GinkgoT())
+
+			session, err := store.Open(testCtx)
+			Expect(err).NotTo(HaveOccurred())
+
+			checkInterval := time.Millisecond * 50
+			releaseCooldown := time.Millisecond * 100
+
+			// no Pod is ever created for this reservation, so it's detected as an orphan
+			Expect(session.Reserve(testPool1, "id1", testIFName, types.ReservationMetadata{
+				CreateTime:   time.Now().Format(time.RFC3339Nano),
+				PodName:      "never-created",
+				PodNamespace: testNamespace,
+			}, net.ParseIP(testOrphanCooldownIP))).NotTo(HaveOccurred())
+			Expect(session.Commit()).NotTo(HaveOccurred())
+
+			cleaner := cleanerPkg.New(fakeClient, k8sClient, store, poolManager, checkInterval, 1, releaseCooldown)
+
+			go func() {
+				cleaner.Start(testCtx)
+			}()
+
+			// once detected as an orphan, it's released the same way a normal CNI DEL is:
+			// marked released and held until releaseCooldown elapses, then removed
+			Eventually(func(g Gomega) {
+				s, err := store.Open(testCtx)
+				g.Expect(err).NotTo(HaveOccurred())
+				defer s.Cancel()
+				g.Expect(storetest.FindReservation(s, testPool1, "id1", testIFName)).To(BeNil())
+			}, 10).Should(Succeed())
+
+			// the IP should be reusable now that the released reservation was removed
+			s, err := store.Open(testCtx)
+			Expect(err).NotTo(HaveOccurred())
+			defer s.Cancel()
+			Expect(s.Reserve(testPool1, "id2", testIFName, types.ReservationMetadata{},
+				net.ParseIP(testOrphanCooldownIP))).NotTo(HaveOccurred())
+		}()
+		Eventually(done, time.Minute).Should(BeClosed())
+	})
+
+	It("Orphan cleanup marks the reservation released and keeps blocking its IP during the cooldown", func() {
+		done := make(chan interface{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+			testCtx, testCancel := context.WithCancel(ctx)
+			defer testCancel()
+			storePath := filepath.Join(GinkgoT().TempDir(), "test_store_orphan_cooldown_pending")
+			store := storePkg.New(storePath)
+
+			poolManager := poolMockPkg.NewManager(GinkgoT())
+
+			session, err := store.Open(testCtx)
+			Expect(err).NotTo(HaveOccurred())
+
+			checkInterval := time.Millisecond * 50
+			releaseCooldown := time.Minute
+
+			Expect(session.Reserve(testPool1, "id1", testIFName, types.ReservationMetadata{
+				CreateTime:   time.Now().Format(time.RFC3339Nano),
+				PodName:      "never-created",
+				PodNamespace: testNamespace,
+			}, net.ParseIP(testOrphanPendingCooldownIP))).NotTo(HaveOccurred())
+			Expect(session.Commit()).NotTo(HaveOccurred())
+
+			cleaner := cleanerPkg.New(fakeClient, k8sClient, store, poolManager, checkInterval, 1, releaseCooldown)
+
+			go func() {
+				cleaner.Start(testCtx)
+			}()
+
+			// orphan detection itself takes a couple of ticks to cross the stale-count
+			// threshold; wait for that transition before asserting it holds steady
+			Eventually(func(g Gomega) {
+				s, err := store.Open(testCtx)
+				g.Expect(err).NotTo(HaveOccurred())
+				defer s.Cancel()
+				res := storetest.FindReservation(s, testPool1, "id1", testIFName)
+				g.Expect(res).NotTo(BeNil())
+				g.Expect(res.IsReleased()).To(BeTrue())
+			}, 10).Should(Succeed())
+
+			// with a one-minute cooldown, the now-released reservation must stay marked
+			// released (not deleted) and its IP must stay blocked across several ticks
+			Consistently(func(g Gomega) {
+				s, err := store.Open(testCtx)
+				g.Expect(err).NotTo(HaveOccurred())
+				defer s.Cancel()
+				res := storetest.FindReservation(s, testPool1, "id1", testIFName)
+				g.Expect(res).NotTo(BeNil())
+				g.Expect(res.IsReleased()).To(BeTrue())
+				g.Expect(
+					s.Reserve(testPool1, "id2", testIFName, types.ReservationMetadata{},
+						net.ParseIP(testOrphanPendingCooldownIP))).To(MatchError(storePkg.ErrIPAlreadyReserved))
 			}, checkInterval*5, checkInterval).Should(Succeed())
 		}()
 		Eventually(done, time.Minute).Should(BeClosed())

--- a/pkg/ipam-node/handlers/deallocate.go
+++ b/pkg/ipam-node/handlers/deallocate.go
@@ -40,11 +40,19 @@ func (h *Handlers) Deallocate(
 	}
 	poolType := poolTypeAsString(params.PoolType)
 	for _, poolName := range params.Pools {
-		store.ReleaseReservationByID(common.GetPoolKey(poolName, poolType), params.CniContainerid, params.CniIfname)
+		poolKey := common.GetPoolKey(poolName, poolType)
+		// with a positive cooldown, the reservation is kept in the store (blocking its
+		// IP from reuse) until the cleaner removes it once the cooldown expires
+		removed := store.ReleaseReservationByID(poolKey, params.CniContainerid, params.CniIfname, h.releaseCooldown)
+		switch {
+		case removed:
+			reqLog.Info("reservation released", "poolKey", poolKey)
+		case h.releaseCooldown > 0:
+			reqLog.Info("reservation marked released, pending release cooldown before its IP is freed", "poolKey", poolKey)
+		}
 	}
 	if err := h.closeSession(ctx, store, nil); err != nil {
 		return nil, err
 	}
-	reqLog.Info("reservation released")
 	return &nodev1.DeallocateResponse{}, nil
 }

--- a/pkg/ipam-node/handlers/handlers.go
+++ b/pkg/ipam-node/handlers/handlers.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc/codes"
@@ -33,11 +34,13 @@ type GetAllocatorFunc = func(s *allocator.RangeSet, exclusions *allocator.RangeS
 	poolKey string, session storePkg.Session) allocator.IPAllocator
 
 // New create and initialize new instance of grpc Handlers
-func New(poolConfReader poolPkg.ConfigReader, store storePkg.Store, getAllocFunc GetAllocatorFunc) *Handlers {
+func New(poolConfReader poolPkg.ConfigReader, store storePkg.Store,
+	getAllocFunc GetAllocatorFunc, releaseCooldown time.Duration) *Handlers {
 	return &Handlers{
-		poolConfReader: poolConfReader,
-		store:          store,
-		getAllocFunc:   getAllocFunc,
+		poolConfReader:  poolConfReader,
+		store:           store,
+		getAllocFunc:    getAllocFunc,
+		releaseCooldown: releaseCooldown,
 	}
 }
 
@@ -46,6 +49,9 @@ type Handlers struct {
 	poolConfReader poolPkg.ConfigReader
 	store          storePkg.Store
 	getAllocFunc   GetAllocatorFunc
+	// releaseCooldown is the minimum time a released reservation is retained in the
+	// store, blocking its IP from reuse, before it becomes eligible for removal
+	releaseCooldown time.Duration
 	nodev1.UnsafeIPAMServiceServer
 }
 

--- a/pkg/ipam-node/handlers/handlers_test.go
+++ b/pkg/ipam-node/handlers/handlers_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -107,7 +108,7 @@ var _ = Describe("Handlers", func() {
 			poolName string, store storePkg.Session) allocatorPkg.IPAllocator {
 			return allocators[poolName]
 		}
-		handlers = handlersPkg.New(poolManager, store, getAllocFunc)
+		handlers = handlersPkg.New(poolManager, store, getAllocFunc, 0)
 	})
 
 	It("Allocate succeed", func() {
@@ -389,19 +390,29 @@ var _ = Describe("Handlers", func() {
 	})
 	It("Deallocate succeed", func() {
 		store.On("Open", mock.Anything).Return(session, nil)
-		session.On("ReleaseReservationByID", testPoolName1, "id1", "net0").Return()
-		session.On("ReleaseReservationByID", testPoolName2, "id1", "net0").Return()
+		session.On("ReleaseReservationByID", testPoolName1, "id1", "net0", time.Duration(0)).Return(true)
+		session.On("ReleaseReservationByID", testPoolName2, "id1", "net0", time.Duration(0)).Return(true)
 		session.On("Commit").Return(nil)
 		_, err := handlers.Deallocate(ctx, &nodev1.DeallocateRequest{Parameters: getValidIPAMParams()})
 		Expect(err).NotTo(HaveOccurred())
 	})
 	It("Deallocate failed: failed to commit", func() {
 		store.On("Open", mock.Anything).Return(session, nil)
-		session.On("ReleaseReservationByID", testPoolName1, "id1", "net0").Return()
-		session.On("ReleaseReservationByID", testPoolName2, "id1", "net0").Return()
+		session.On("ReleaseReservationByID", testPoolName1, "id1", "net0", time.Duration(0)).Return(true)
+		session.On("ReleaseReservationByID", testPoolName2, "id1", "net0", time.Duration(0)).Return(true)
 		session.On("Commit").Return(fmt.Errorf("test error"))
 		_, err := handlers.Deallocate(ctx, &nodev1.DeallocateRequest{Parameters: getValidIPAMParams()})
 		Expect(status.Code(err) == codes.Internal).To(BeTrue())
+	})
+	It("Deallocate with a release cooldown forwards it to the store", func() {
+		releaseCooldown := time.Minute
+		cooldownHandlers := handlersPkg.New(poolManager, store, getAllocFunc, releaseCooldown)
+		store.On("Open", mock.Anything).Return(session, nil)
+		session.On("ReleaseReservationByID", testPoolName1, "id1", "net0", releaseCooldown).Return(true)
+		session.On("ReleaseReservationByID", testPoolName2, "id1", "net0", releaseCooldown).Return(true)
+		session.On("Commit").Return(nil)
+		_, err := cooldownHandlers.Deallocate(ctx, &nodev1.DeallocateRequest{Parameters: getValidIPAMParams()})
+		Expect(err).NotTo(HaveOccurred())
 	})
 	It("Deallocate failed: canceled", func() {
 		store.On("Open", mock.Anything).Return(session, nil)

--- a/pkg/ipam-node/store/mocks/Session.go
+++ b/pkg/ipam-node/store/mocks/Session.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	net "net"
+	time "time"
 
 	mock "github.com/stretchr/testify/mock"
 
@@ -293,9 +294,22 @@ func (_c *Session_ListReservations_Call) RunAndReturn(run func(string) []types.R
 	return _c
 }
 
-// ReleaseReservationByID provides a mock function with given fields: poolKey, id, ifName
-func (_m *Session) ReleaseReservationByID(poolKey string, id string, ifName string) {
-	_m.Called(poolKey, id, ifName)
+// ReleaseReservationByID provides a mock function with given fields: poolKey, id, ifName, cooldown
+func (_m *Session) ReleaseReservationByID(poolKey string, id string, ifName string, cooldown time.Duration) bool {
+	ret := _m.Called(poolKey, id, ifName, cooldown)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReleaseReservationByID")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, string, string, time.Duration) bool); ok {
+		r0 = rf(poolKey, id, ifName, cooldown)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
 }
 
 // Session_ReleaseReservationByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReleaseReservationByID'
@@ -307,23 +321,24 @@ type Session_ReleaseReservationByID_Call struct {
 //   - poolKey string
 //   - id string
 //   - ifName string
-func (_e *Session_Expecter) ReleaseReservationByID(poolKey interface{}, id interface{}, ifName interface{}) *Session_ReleaseReservationByID_Call {
-	return &Session_ReleaseReservationByID_Call{Call: _e.mock.On("ReleaseReservationByID", poolKey, id, ifName)}
+//   - cooldown time.Duration
+func (_e *Session_Expecter) ReleaseReservationByID(poolKey interface{}, id interface{}, ifName interface{}, cooldown interface{}) *Session_ReleaseReservationByID_Call {
+	return &Session_ReleaseReservationByID_Call{Call: _e.mock.On("ReleaseReservationByID", poolKey, id, ifName, cooldown)}
 }
 
-func (_c *Session_ReleaseReservationByID_Call) Run(run func(poolKey string, id string, ifName string)) *Session_ReleaseReservationByID_Call {
+func (_c *Session_ReleaseReservationByID_Call) Run(run func(poolKey string, id string, ifName string, cooldown time.Duration)) *Session_ReleaseReservationByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(string))
+		run(args[0].(string), args[1].(string), args[2].(string), args[3].(time.Duration))
 	})
 	return _c
 }
 
-func (_c *Session_ReleaseReservationByID_Call) Return() *Session_ReleaseReservationByID_Call {
-	_c.Call.Return()
+func (_c *Session_ReleaseReservationByID_Call) Return(_a0 bool) *Session_ReleaseReservationByID_Call {
+	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *Session_ReleaseReservationByID_Call) RunAndReturn(run func(string, string, string)) *Session_ReleaseReservationByID_Call {
+func (_c *Session_ReleaseReservationByID_Call) RunAndReturn(run func(string, string, string, time.Duration) bool) *Session_ReleaseReservationByID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/ipam-node/store/store.go
+++ b/pkg/ipam-node/store/store.go
@@ -52,7 +52,9 @@ type Session interface {
 	// Reserve reserves IP for the id and interface name,
 	// returns error if allocation failed
 	Reserve(poolKey string, id string, ifName string, meta types.ReservationMetadata, address net.IP) error
-	// ListReservations list all reservations in the pool
+	// ListReservations lists all reservations in the pool, including ones already
+	// released by their owner and pending removal once their cooldown elapses (see
+	// ReleaseReservationByID). Unlike GetReservationByID, it does not filter those out.
 	ListReservations(poolKey string) []types.Reservation
 	// ListPools return list with names of all known pools
 	ListPools() []string
@@ -62,10 +64,26 @@ type Session interface {
 	GetLastReservedIP(poolKey string) net.IP
 	// SetLastReservedIP set last reserved IP fot the pool
 	SetLastReservedIP(poolKey string, ip net.IP)
-	// ReleaseReservationByID releases reservation by id and interface name
-	ReleaseReservationByID(poolKey string, id string, ifName string)
-	// GetReservationByID returns existing reservation for id and interface name,
-	// return nil if allocation not found
+	// ReleaseReservationByID releases the reservation identified by id and interface name.
+	// Returns true if the reservation was actually removed from the store.
+	//
+	// If cooldown <= 0, the reservation is removed immediately, regardless of any prior
+	// release state.
+	//
+	// If cooldown > 0:
+	//   - a reservation not yet marked released is marked released now (kept in the
+	//     store, still blocking its IP from reuse) instead of being removed. The
+	//     release timestamp is set once and is not reset by later calls, since CNI DEL
+	//     is idempotent and may be retried for the same id/ifName.
+	//   - a reservation already marked released is removed once its cooldown has
+	//     elapsed; otherwise this call is a no-op.
+	//
+	// This is a no-op (returns false) if the reservation does not exist.
+	ReleaseReservationByID(poolKey string, id string, ifName string, cooldown time.Duration) bool
+	// GetReservationByID returns the existing, still-active reservation for id and
+	// interface name. Returns nil if not found, including for a reservation that has
+	// already been released by its owner and is only pending removal (see
+	// ReleaseReservationByID).
 	GetReservationByID(poolKey string, id string, ifName string) *types.Reservation
 	// Commit writes persistedData to the disk and release the lock.
 	// the store can't be used after this call
@@ -193,20 +211,18 @@ func (s *session) Reserve(poolKey string, id string, ifName string,
 	s.checkClosed()
 	reservationKey := s.getKey(id, ifName)
 	poolData := s.getPoolData(poolKey, s.tmpData)
-	_, exist := poolData.Entries[reservationKey]
-	if exist {
+	// A reservation pending its release cooldown (IsReleased() == true) still occupies
+	// this key and blocks it, exactly like an active one: the cooldown is a floor on
+	// reuse of the address, and that applies to its own former owner too, not just other
+	// callers.
+	if _, exist := poolData.Entries[reservationKey]; exist {
 		return ErrReservationAlreadyExist
 	}
-	duplicateIP := false
 	for _, r := range poolData.Entries {
 		if address.Equal(r.IPAddress) {
-			duplicateIP = true
-			break
+			// duplicate allocator should retry
+			return ErrIPAlreadyReserved
 		}
-	}
-	if duplicateIP {
-		// duplicate allocator should retry
-		return ErrIPAlreadyReserved
 	}
 	poolData.LastReservedIP = address
 	poolData.LastPoolConfig = meta.PoolConfigSnapshot
@@ -218,9 +234,14 @@ func (s *session) Reserve(poolKey string, id string, ifName string,
 	}
 	reservation.Metadata.CreateTime = time.Now().Format(time.RFC3339Nano)
 	poolData.Entries[reservationKey] = reservation
+	s.updatePoolData(poolKey, poolData)
+	return nil
+}
+
+// updatePoolData stores poolData under poolKey in the session and marks it modified.
+func (s *session) updatePoolData(poolKey string, poolData *types.PoolReservations) {
 	s.tmpData.Pools[poolKey] = *poolData
 	s.isModified = true
-	return nil
 }
 
 func (s *session) getPoolData(poolKey string, layout *types.Root) *types.PoolReservations {
@@ -274,17 +295,32 @@ func (s *session) SetLastReservedIP(poolKey string, ip net.IP) {
 	s.checkClosed()
 	poolData := s.getPoolData(poolKey, s.tmpData)
 	poolData.LastReservedIP = ip
-	s.tmpData.Pools[poolKey] = *poolData
-	s.isModified = true
+	s.updatePoolData(poolKey, poolData)
 }
 
 // ReleaseReservationByID is the Session interface implementation for session
-func (s *session) ReleaseReservationByID(poolKey string, id string, ifName string) {
+func (s *session) ReleaseReservationByID(poolKey string, id string, ifName string, cooldown time.Duration) bool {
 	s.checkClosed()
+	key := s.getKey(id, ifName)
 	poolData := s.getPoolData(poolKey, s.tmpData)
-	delete(poolData.Entries, s.getKey(id, ifName))
-	s.tmpData.Pools[poolKey] = *poolData
-	s.isModified = true
+	reservation, exist := poolData.Entries[key]
+	if !exist {
+		return false
+	}
+	expired := reservation.IsReleased() && time.Since(reservation.ReleasedAt) >= cooldown
+	if cooldown > 0 && reservation.IsReleased() && !expired {
+		return false
+	}
+
+	remove := cooldown <= 0 || expired
+	if remove {
+		delete(poolData.Entries, key)
+	} else {
+		reservation.ReleasedAt = time.Now()
+		poolData.Entries[key] = reservation
+	}
+	s.updatePoolData(poolKey, poolData)
+	return remove
 }
 
 // GetReservationByID is the Session interface implementation for session
@@ -292,7 +328,7 @@ func (s *session) GetReservationByID(poolKey string, id string, ifName string) *
 	s.checkClosed()
 	poolData := s.getPoolData(poolKey, s.tmpData)
 	reservation, exist := poolData.Entries[s.getKey(id, ifName)]
-	if !exist {
+	if !exist || reservation.IsReleased() {
 		return nil
 	}
 	return &reservation

--- a/pkg/ipam-node/store/store_test.go
+++ b/pkg/ipam-node/store/store_test.go
@@ -26,11 +26,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	storePkg "github.com/Mellanox/nvidia-k8s-ipam/pkg/ipam-node/store"
+	"github.com/Mellanox/nvidia-k8s-ipam/pkg/ipam-node/store/storetest"
 	"github.com/Mellanox/nvidia-k8s-ipam/pkg/ipam-node/types"
 )
 
 const (
-	testPoolKey      = "pool1"
+	testPoolKey       = "pool1"
 	testContainerID   = "id1"
 	testNetIfName     = "net0"
 	testPodUUID       = "a9516e9d-6f45-4693-b299-cc3d2f83e26a"
@@ -93,7 +94,7 @@ var _ = Describe("Store", func() {
 		Expect(s.GetLastReservedIP(testPoolKey)).To(Equal(newLastReservedIP))
 
 		By("Release reservation")
-		s.ReleaseReservationByID(testPoolKey, testContainerID, testNetIfName)
+		s.ReleaseReservationByID(testPoolKey, testContainerID, testNetIfName, 0)
 
 		By("Check reservation removed")
 		Expect(s.GetReservationByID(testPoolKey, testContainerID, testNetIfName)).To(BeNil())
@@ -237,5 +238,112 @@ var _ = Describe("Store", func() {
 		Expect(s.ListReservations(testPoolKey)).NotTo(BeEmpty())
 		s.RemovePool(testPoolKey)
 		Expect(s.ListReservations(testPoolKey)).To(BeEmpty())
+	})
+	It("Release with a cooldown marks the reservation released instead of removing it", func() {
+		s, err := store.Open(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		createTestReservation(s)
+
+		By("Release with a cooldown")
+		s.ReleaseReservationByID(testPoolKey, testContainerID, testNetIfName, time.Minute)
+
+		By("GetReservationByID treats it as gone, since its owner already released it")
+		Expect(s.GetReservationByID(testPoolKey, testContainerID, testNetIfName)).To(BeNil())
+
+		By("But the entry is retained and still blocks the IP from reuse")
+		res := storetest.FindReservation(s, testPoolKey, testContainerID, testNetIfName)
+		Expect(res).NotTo(BeNil())
+		Expect(res.IsReleased()).To(BeTrue())
+		Expect(res.ReleasedAt).NotTo(BeZero())
+		Expect(
+			s.Reserve(testPoolKey, "other", testNetIfName,
+				types.ReservationMetadata{}, net.ParseIP(testIP))).To(MatchError(storePkg.ErrIPAlreadyReserved))
+
+		By("A retried release (e.g. idempotent CNI DEL) does not reset the release timestamp")
+		firstReleasedAt := res.ReleasedAt
+		s.ReleaseReservationByID(testPoolKey, testContainerID, testNetIfName, time.Minute)
+		res = storetest.FindReservation(s, testPoolKey, testContainerID, testNetIfName)
+		Expect(res).NotTo(BeNil())
+		Expect(res.ReleasedAt).To(Equal(firstReleasedAt))
+
+		By("It is not removed before the cooldown elapses")
+		s.ReleaseReservationByID(testPoolKey, testContainerID, testNetIfName, time.Hour)
+		Expect(storetest.FindReservation(s, testPoolKey, testContainerID, testNetIfName)).NotTo(BeNil())
+
+		By("It is removed, freeing the IP, once the cooldown has elapsed")
+		s.ReleaseReservationByID(testPoolKey, testContainerID, testNetIfName, time.Nanosecond)
+		Expect(storetest.FindReservation(s, testPoolKey, testContainerID, testNetIfName)).To(BeNil())
+		Expect(
+			s.Reserve(testPoolKey, "other", testNetIfName,
+				types.ReservationMetadata{}, net.ParseIP(testIP))).NotTo(HaveOccurred())
+	})
+	It("Release with no cooldown removes the reservation immediately", func() {
+		s, err := store.Open(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		createTestReservation(s)
+		s.ReleaseReservationByID(testPoolKey, testContainerID, testNetIfName, 0)
+		Expect(storetest.FindReservation(s, testPoolKey, testContainerID, testNetIfName)).To(BeNil())
+	})
+	It("Release is a no-op for an unknown reservation", func() {
+		s, err := store.Open(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(func() { s.ReleaseReservationByID(testPoolKey, testContainerID, testNetIfName, time.Minute) }).NotTo(Panic())
+		Expect(s.GetReservationByID(testPoolKey, testContainerID, testNetIfName)).To(BeNil())
+
+		By("it does not dirty the session, so Commit does not write to disk")
+		Expect(s.Commit()).NotTo(HaveOccurred())
+		_, err = os.Stat(storePath)
+		Expect(err).To(MatchError(os.ErrNotExist))
+	})
+	It("Retrying a release before the cooldown elapses does not write to disk again", func() {
+		s, err := store.Open(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		createTestReservation(s)
+		// first release: transitions the reservation to Released, which does need
+		// persisting so it survives a restart
+		Expect(s.ReleaseReservationByID(testPoolKey, testContainerID, testNetIfName, time.Hour)).To(BeFalse())
+		Expect(s.Commit()).NotTo(HaveOccurred())
+
+		s, err = store.Open(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		fileInfoBefore, err := os.Stat(storePath)
+		Expect(err).NotTo(HaveOccurred())
+
+		// retried release (e.g. idempotent CNI DEL): already Released, cooldown not
+		// elapsed yet -- a genuine no-op that should not dirty the session
+		Expect(s.ReleaseReservationByID(testPoolKey, testContainerID, testNetIfName, time.Hour)).To(BeFalse())
+		Expect(s.Commit()).NotTo(HaveOccurred())
+
+		fileInfoAfter, err := os.Stat(storePath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fileInfoAfter.ModTime()).To(Equal(fileInfoBefore.ModTime()))
+	})
+	It("Re-reserving the same id/ifName is rejected while its cooldown is pending, "+
+		"even at the exact same address", func() {
+		s, err := store.Open(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		createTestReservation(s)
+		s.ReleaseReservationByID(testPoolKey, testContainerID, testNetIfName, time.Minute)
+
+		By("the cooldown is a floor on reuse of the address, including by its own former owner")
+		Expect(
+			s.Reserve(testPoolKey, testContainerID, testNetIfName,
+				types.ReservationMetadata{}, net.ParseIP(testIP))).To(MatchError(storePkg.ErrReservationAlreadyExist))
+
+		By("the reservation is untouched and still blocks the address")
+		res := storetest.FindReservation(s, testPoolKey, testContainerID, testNetIfName)
+		Expect(res).NotTo(BeNil())
+		Expect(res.IPAddress).To(Equal(net.ParseIP(testIP)))
+		Expect(res.IsReleased()).To(BeTrue())
+	})
+	It("A different id/ifName targeting a cooling-down address gets a retryable error", func() {
+		s, err := store.Open(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		createTestReservation(s)
+		s.ReleaseReservationByID(testPoolKey, testContainerID, testNetIfName, time.Minute)
+
+		Expect(
+			s.Reserve(testPoolKey, "other", testNetIfName,
+				types.ReservationMetadata{}, net.ParseIP(testIP))).To(MatchError(storePkg.ErrIPAlreadyReserved))
 	})
 })

--- a/pkg/ipam-node/store/storetest/storetest.go
+++ b/pkg/ipam-node/store/storetest/storetest.go
@@ -1,0 +1,32 @@
+/*
+ Copyright 2023, NVIDIA CORPORATION & AFFILIATES
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Package storetest holds small helpers shared by store.Session tests across packages.
+package storetest
+
+import (
+	"github.com/Mellanox/nvidia-k8s-ipam/pkg/ipam-node/store"
+	"github.com/Mellanox/nvidia-k8s-ipam/pkg/ipam-node/types"
+)
+
+// FindReservation looks up a reservation via ListReservations, so it can find one still
+// pending its release cooldown, unlike Session.GetReservationByID which hides those.
+// Returns nil if no matching reservation is found.
+func FindReservation(s store.Session, poolKey, containerID, ifName string) *types.Reservation {
+	for _, r := range s.ListReservations(poolKey) {
+		if r.ContainerID == containerID && r.InterfaceName == ifName {
+			return &r
+		}
+	}
+	return nil
+}

--- a/pkg/ipam-node/types/checksum.go
+++ b/pkg/ipam-node/types/checksum.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"hash/fnv"
+	"time"
 )
 
 var (
@@ -41,14 +42,23 @@ func NewChecksum(r *Root) Checksum {
 
 // Get returns calculated checksum for the Root object
 func getChecksum(r *Root) uint32 {
+	stripped := r.DeepCopy()
+	stripped.Checksum = 0
+	// Zero ReleasedAt: an older binary's Reservation type predates this field and drops
+	// it on load, so including it here would make that binary compute a different
+	// checksum than the one stored, breaking rollback (nvidia-k8s-ipam#301).
+	for _, pool := range stripped.Pools {
+		for key, entry := range pool.Entries {
+			entry.ReleasedAt = time.Time{}
+			pool.Entries[key] = entry
+		}
+	}
+
 	h := fnv.New32a()
-	tmpChecksum := r.Checksum
-	r.Checksum = 0
-	data, err := json.Marshal(r)
+	data, err := json.Marshal(stripped)
 	if err != nil {
 		panic("failed to compute checksum for input data")
 	}
-	r.Checksum = tmpChecksum
 	_, _ = h.Write(data)
 	return h.Sum32()
 }

--- a/pkg/ipam-node/types/checksum_test.go
+++ b/pkg/ipam-node/types/checksum_test.go
@@ -14,6 +14,8 @@
 package types_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -28,5 +30,21 @@ var _ = Describe("Checksum", func() {
 		r1 := types.NewRoot()
 		r1.Pools["foo"] = *types.NewPoolReservations("foo")
 		Expect(types.NewChecksum(r1).Verify(types.NewRoot())).To(HaveOccurred())
+	})
+	It("ReleasedAt does not affect the v1 checksum, so an older binary can still verify it", func() {
+		r := types.NewRoot()
+		r.Pools["pool1"] = *types.NewPoolReservations("pool1")
+		r.Pools["pool1"].Entries["id1_net0"] = types.Reservation{ContainerID: "id1", InterfaceName: "net0"}
+		checksumBeforeRelease := types.NewChecksum(r)
+
+		entry := r.Pools["pool1"].Entries["id1_net0"]
+		entry.ReleasedAt = time.Now()
+		r.Pools["pool1"].Entries["id1_net0"] = entry
+
+		Expect(types.NewChecksum(r)).To(Equal(checksumBeforeRelease),
+			"setting ReleasedAt must not change the checksum, or a store file with a "+
+				"cooldown-pending reservation would fail 'checksum mismatch' on an older "+
+				"binary that predates ReleasedAt and silently drops it on load")
+		Expect(checksumBeforeRelease.Verify(r)).NotTo(HaveOccurred())
 	})
 })

--- a/pkg/ipam-node/types/types.go
+++ b/pkg/ipam-node/types/types.go
@@ -16,6 +16,7 @@ package types
 import (
 	"encoding/json"
 	"net"
+	"time"
 )
 
 // ImplementedVersion contains implemented version of the store file layout
@@ -96,6 +97,17 @@ type Reservation struct {
 	InterfaceName string              `json:"interface_name"`
 	IPAddress     net.IP              `json:"ip_address"`
 	Metadata      ReservationMetadata `json:"metadata"`
+	// ReleasedAt is the time at which the reservation was released by its owner (e.g. CNI
+	// DEL). A zero value means the reservation is still active. A non-zero value means it
+	// is only being retained in the store for the release cooldown period, and still
+	// blocks its IP from being reused until the cooldown expires.
+	ReleasedAt time.Time `json:"released_at,omitzero"`
+}
+
+// IsReleased reports whether the reservation has been released by its owner and is only
+// being retained for the release cooldown period.
+func (r *Reservation) IsReleased() bool {
+	return !r.ReleasedAt.IsZero()
 }
 
 // DeepCopy is a deepcopy function for the Reservation struct


### PR DESCRIPTION
`ipam-node` had two related but distinct gaps around releasing and reusing IP allocations, both rooted in issue #181:

1. The stale-IP cleaner (for allocations whose Pod can no longer be found — e.g. a crashed
   node, a force-deleted Pod) hardcoded its check interval (1 minute) and stale-check count
   (3), giving every deployment the same ~3 minute effective TTL with no way to tune it.
2. More importantly — as flagged in review — the normal CNI DEL path released an
   allocation's IP **immediately**, with no cooldown at all. Some environments need a
   cooldown before a released IP can be reused (e.g. downstream ARP/connection-tracking
   state on the network fabric needs time to clear), which the original version of this PR
   didn't provide despite referencing #181.

This PR now addresses both, via two independent flags on `ipam-node`:

* `--stale-ip-check-interval` (default `1m`) and `--stale-ip-check-count-before-release`
  (default `3`): unchanged from the original scope of this PR — configure how often, and
  after how many failed checks, an allocation with no matching Pod is released. This is
  about orphan detection, not a release cooldown.
* `--released-ip-cooldown` (default `0`, disabled): the actual cooldown. When set, a
  released reservation (from a normal CNI DEL, or from the stale-allocation cleanup above)
  is *retained* in the store — still blocking its IP from reuse — instead of being deleted
  outright. The cleaner removes it, freeing the IP, once the cooldown has elapsed. A value
  of `0` preserves the exact prior behavior (immediate release).

## Trade-off notes

* The cooldown applies uniformly regardless of *how* a reservation was released — a normal
  CNI DEL and an orphan detected by the stale-allocation cleaner both go through the same
  cooldown. There's exactly one cooldown clock per released IP, not two.
* The cooldown blocks reuse by *any* caller, including a retried CNI ADD for the same
  container/interface that released the IP. This is deliberate: the cooldown exists to let
  network-fabric state (ARP caches, connection tracking, etc.) settle, which doesn't care
  about Kubernetes container identity — a crash-looping Pod repeatedly tearing down and
  recreating its interface on the same IP is exactly the scenario the cooldown needs to
  cover, not one to exempt. A retried ADD during the cooldown window fails with
  `AlreadyExists` and succeeds once the cooldown clears.
* No CRD/API change: like the existing flags, this is a global, per-`ipam-node` setting,
  not a per-`IPPool` field. Per-pool cooldowns are a reasonable follow-up if a real need for
  different cooldowns per pool shows up, but that's a separate design discussion.
* Fully backward compatible: default is `0` (disabled), so existing deployments that don't
  set the flag keep the current immediate-release behavior exactly.

## How to validate/test

* `make build && make test` passes.
* New unit/integration coverage: `pkg/ipam-node/store`, `pkg/ipam-node/cleaner`,
  `pkg/ipam-node/handlers`, and `pkg/ipam-node/allocator` all have new test cases covering
  the cooldown — marking a reservation released without removing it, blocking reuse while
  pending, expiring it once the cooldown elapses, and rejecting a same-container reclaim
  attempt during the cooldown window.
* Manually: run `ipam-node` with `--released-ip-cooldown=1m`, allocate an IP for a Pod,
  delete the Pod (CNI DEL), and confirm via logs ("reservation marked released, pending
  release cooldown...") that the IP is not handed out to a new allocation request until
  ~1 minute has passed, at which point the cleaner logs its removal and the IP becomes
  available again.
* Defaults are unchanged, so existing deployments that don't set `--released-ip-cooldown`
  see no behavior change at all.

Addresses #181

---
Drafted with AI assistance (Claude); I reviewed, tested, and take responsibility for all changes.